### PR TITLE
Implementation of UnitTests for MetadataAPI using scalatest methodology

### DIFF
--- a/trunk/MetadataAPI/build.sbt
+++ b/trunk/MetadataAPI/build.sbt
@@ -10,6 +10,8 @@ assemblyOption in assembly ~= { _.copy(prependShellScript = Some(defaultShellScr
 
 jarName in assembly := { s"${name.value}-${version.value}" }
 
+test in assembly := {}
+
 // for some reason the merge strategy for non ligadata classes are not working and thus added those conflicting jars in exclusions
 // this may result some run time errors
 

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPIImpl.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPIImpl.scala
@@ -56,12 +56,12 @@ import java.util.Date
 
 case class JsonException(message: String) extends Exception(message)
 
-case class TypeDef(MetadataType: String, NameSpace: String, Name: String, TypeTypeName: String, TypeNameSpace: String, TypeName: String, PhysicalName: String, var Version: String, JarName: String, DependencyJars: List[String], Implementation: String, Fixed: Option[Boolean], NumberOfDimensions: Option[Int], KeyTypeNameSpace: Option[String], KeyTypeName: Option[String], ValueTypeNameSpace: Option[String], ValueTypeName: Option[String], TupleDefinitions: Option[List[TypeDef]])
-case class TypeDefList(Types: List[TypeDef])
+//case class TypeDef(MetadataType: String, NameSpace: String, Name: String, TypeTypeName: String, TypeNameSpace: String, TypeName: String, PhysicalName: String, var Version: String, JarName: String, DependencyJars: List[String], Implementation: String, Fixed: Option[Boolean], NumberOfDimensions: Option[Int], KeyTypeNameSpace: Option[String], KeyTypeName: Option[String], ValueTypeNameSpace: Option[String], ValueTypeName: Option[String], TupleDefinitions: Option[List[TypeDef]])
+//case class TypeDefList(Types: List[TypeDef])
 
-case class Argument(ArgName: String, ArgTypeNameSpace: String, ArgTypeName: String)
-case class Function(NameSpace: String, Name: String, PhysicalName: String, ReturnTypeNameSpace: String, ReturnTypeName: String, Arguments: List[Argument], Version: String, JarName: String, DependantJars: List[String])
-case class FunctionList(Functions: List[Function])
+//case class Argument(ArgName: String, ArgTypeNameSpace: String, ArgTypeName: String)
+//case class Function(NameSpace: String, Name: String, PhysicalName: String, ReturnTypeNameSpace: String, ReturnTypeName: String, Arguments: List[Argument], Version: String, JarName: String, DependantJars: List[String])
+//case class FunctionList(Functions: List[Function])
 
 //case class Concept(NameSpace: String,Name: String, TypeNameSpace: String, TypeName: String,Version: String,Description: String, Author: String, ActiveDate: String)
 case class Concept(NameSpace: String, Name: String, TypeNameSpace: String, TypeName: String, Version: String)
@@ -99,7 +99,7 @@ case class ContainerDefParsingException(e: String) extends Exception(e)
 case class ModelDefParsingException(e: String) extends Exception(e)
 case class ApiResultParsingException(e: String) extends Exception(e)
 case class UnexpectedMetadataAPIException(e: String) extends Exception(e)
-case class ObjectNotFoundException(e: String) extends Exception(e)
+//case class ObjectNotFoundException(e: String) extends Exception(e)
 case class CreateStoreFailedException(e: String) extends Exception(e)
 case class UpdateStoreFailedException(e: String) extends Exception(e)
 
@@ -550,6 +550,11 @@ object MetadataAPIImpl extends MetadataAPI {
   private var configStore: DataStore = _
 
   def oStore = otherStore
+
+  def GetMetadataStore: DataStore = metadataStore
+  def GetConfigStore: DataStore = configStore
+  def GetJarStore: DataStore = jarStore
+  def GetTransStore: DataStore = transStore
 
   def KeyAsStr(k: com.ligadata.keyvaluestore.Key): String = {
     val k1 = k.toArray[Byte]
@@ -1833,6 +1838,7 @@ object MetadataAPIImpl extends MetadataAPI {
           var apiResult = new ApiResult(ErrorCodeConstants.Failure, "RemoveType", null, ErrorCodeConstants.Remove_Type_Not_Found + ":" + dispkey)
           apiResult.toString()
         case Some(ts) =>
+          logger.debug("Type " + dispkey + " is will be deleted ")
           DeleteObject(ts.asInstanceOf[BaseElemDef])
          var apiResult = new ApiResult(ErrorCodeConstants.Success, "RemoveType", null, ErrorCodeConstants.Remove_Type_Successful + ":" + dispkey)
           apiResult.toString()
@@ -2048,7 +2054,12 @@ object MetadataAPIImpl extends MetadataAPI {
     var key = functionName + ":" + version
     val dispkey = functionName + "." + MdMgr.Pad0s2Version(version)
     try {
-      DeleteObject(key, functionStore)
+      val funcDefs = MdMgr.GetMdMgr.FunctionsAvailable(nameSpace, functionName)
+      if (funcDefs != null) {
+	funcDefs.foreach(func => {
+	  DeleteObject(func)
+	})
+      }
       var apiResult = new ApiResult(ErrorCodeConstants.Success, "RemoveFunction", null, ErrorCodeConstants.Remove_Function_Successfully + ":" + dispkey)
       apiResult.toString()
     } catch {

--- a/trunk/MetadataAPI/src/test/scala/APIInitSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/APIInitSpec.scala
@@ -1,0 +1,88 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+
+import java.io.{ByteArrayOutputStream, _}
+import com.datastax.driver.core.Cluster
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.ligadata.Serialize._
+import com.ligadata.ZooKeeper._
+import com.ligadata.keyvaluestore._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadataload.MetadataLoad
+import com.twitter.chill.ScalaKryoInstantiator
+
+import com.ligadata.ZooKeeper._
+import org.apache.curator.framework.CuratorFramework
+import org.apache.zookeeper.CreateMode
+
+import org.apache.log4j._
+import org.apache.zookeeper.CreateMode
+import scala.collection.mutable.ArrayBuffer
+import scala.io._
+
+class APIInitSpec extends CheckAPIPropSpec {
+
+  private val loggerName = this.getClass.getName
+  private val logger = Logger.getLogger(loggerName)
+
+  describe("Verify very basic operations") {
+    it ("Validate serialization, storage , zookeeper operations ") {
+      logger.setLevel(Level.INFO)
+      noException should be thrownBy {
+	val cfg = MetadataAPIImpl.GetMetadataAPIConfig
+	val db = cfg.getProperty("DATABASE")
+	var fh = System.getenv("FATAFAT_HOME")
+	val zkConnStr = cfg.getProperty("ZOOKEEPER_CONNECT_STRING")
+
+	And("Validate creation of a database connection")
+	val store = MetadataAPIImpl.GetDataStoreHandle(db, "test_store", "test_objects")
+	assert(null != store)
+
+	And("Check database save ")
+	val serializer = SerializerManager.GetSerializer("kryo")
+	val key = "key1"
+	var ba = serializer.SerializeObjectToByteArray("value1")
+	MetadataAPIImpl.UpdateObject(key,ba,store)
+
+
+	And("Check database get")
+	var obj = MetadataAPIImpl.GetObject("key1",store)
+	var v = serializer.DeserializeObjectFromByteArray(obj.Value.toArray[Byte]).asInstanceOf[String]
+	assert(v == "value1")
+
+	And("Validate database connection shutdown")
+        store.Shutdown()
+	
+	And("Check Zookeeper connection")
+	val zkPath = cfg.getProperty("ZNODE_PATH")
+	val znodePath = zkPath + "/metadataupdate"
+	CreateClient.CreateNodeIfNotExists(zkConnStr, znodePath)
+	val zkc = CreateClient.createSimple(zkConnStr)
+	assert(null != zkc)
+
+	And("Bootstrap metadata manager")
+	MdMgr.GetMdMgr.truncate
+	val mdLoader = new MetadataLoad(MdMgr.mdMgr, "", "", "", "")
+	mdLoader.initialize
+
+	And("Setup database connection(handle) to various tables")
+	MetadataAPIImpl.OpenDbStore(db)
+	assert(null != MetadataAPIImpl.GetMetadataStore)
+	assert(null != MetadataAPIImpl.GetConfigStore)
+	assert(null != MetadataAPIImpl.GetJarStore)
+	assert(null != MetadataAPIImpl.GetTransStore)
+
+	And("Initialize everything including related to MetadataAPI execution")
+	var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+	MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+	And("Execute shutdown")
+	MetadataAPIImpl.shutdown
+      }
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/CheckAPIPropSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/CheckAPIPropSpec.scala
@@ -1,0 +1,134 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+
+import java.io.{ByteArrayOutputStream, _}
+import com.datastax.driver.core.Cluster
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.ligadata.Serialize._
+import com.ligadata.ZooKeeper._
+import com.ligadata.keyvaluestore._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadataload.MetadataLoad
+import com.twitter.chill.ScalaKryoInstantiator
+
+import com.ligadata.ZooKeeper._
+import org.apache.curator.framework.CuratorFramework
+import org.apache.zookeeper.CreateMode
+
+import org.apache.log4j._
+import org.apache.zookeeper.CreateMode
+import scala.collection.mutable.ArrayBuffer
+import scala.io._
+
+class CheckAPIPropSpec extends FunSpec with GivenWhenThen {
+
+  private val loggerName = this.getClass.getName
+  private val logger = Logger.getLogger(loggerName)
+
+  describe("Verify properties in the environment") {
+    it ("Read and validate properties from MetadataAPIConfig.properties") {
+
+      And("The environment variable FATAFAT_HOME must be defined ")
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      MetadataAPIImpl.readMetadataAPIConfigFromPropertiesFile(myConfigFile)
+
+      And("MetadataAPIImpl.GetMetadataAPIConfig should have been initialized")
+      val cfg = MetadataAPIImpl.GetMetadataAPIConfig
+      assert(null != cfg)
+
+      And("The property DATABASE must have been defined")
+      val db = cfg.getProperty("DATABASE")
+      assert(null != db)
+      if ( db == "cassandra" ){
+	And("The property MetadataLocation must have been defined for store type " + db)
+	val loc = cfg.getProperty("DATABASE_LOCATION")
+	assert(null != loc)
+	And("The property MetadataSchemaName must have been defined for store type " + db)
+	val schema = cfg.getProperty("DATABASE_SCHEMA")
+	assert(null != schema)
+      }
+      And("The property NODE_ID must have been defined")
+      assert(null != cfg.getProperty("NODE_ID"))  
+
+      
+      And("The property JAR_TRAGET_DIR must have been defined")
+      val d = cfg.getProperty("JAR_TARGET_DIR")
+      assert(null != d)
+
+      And("Make sure the Directory " + d + " exists")
+      val f = new File(d)
+      assert(null != f)
+
+      And("The property SCALA_HOME must have been defined")
+      val sh = cfg.getProperty("SCALA_HOME")
+      assert(null != sh)
+
+      And("The property JAVA_HOME must have been defined")
+      val jh = cfg.getProperty("SCALA_HOME")
+      assert(null != jh)
+
+      And("The property CLASSPATH must have been defined")
+      val cp = cfg.getProperty("CLASSPATH")
+      assert(null != cp)
+
+      And("The property ZNODE_PATH must have been defined")
+      val zkPath = cfg.getProperty("ZNODE_PATH")
+      assert(null != zkPath)
+
+      And("The property ZOOKEEPER_CONNECT_STRING must have been defined")
+      val zkConnStr = cfg.getProperty("ZOOKEEPER_CONNECT_STRING")
+      assert(null != zkConnStr)
+
+      And("The property SERVICE_HOST must have been defined")
+      val shost = cfg.getProperty("SERVICE_HOST")
+      assert(null != shost)
+
+      And("The property SERVICE_PORT must have been defined")
+      val sport = cfg.getProperty("SERVICE_PORT")
+      assert(null != sport)
+
+      And("The property JAR_PATHS must have been defined")
+      val jp = cfg.getProperty("JAR_PATHS")
+      assert(null != jp)
+
+      And("The property SECURITY_IMPL_JAR  must have been defined")
+      val sij = cfg.getProperty("SECURITY_IMPL_JAR")
+      assert(null != sij)
+
+      And("The property SECURITY_IMPL_CLASS  must have been defined")
+      val sic = cfg.getProperty("SECURITY_IMPL_CLASS")
+      assert(null != sic)
+
+      And("The property DO_AUTH  must have been defined")
+      val da = cfg.getProperty("DO_AUTH")
+      assert(null != da)
+
+      And("The property AUDIT_IMPL_JAR  must have been defined")
+      val aij = cfg.getProperty("AUDIT_IMPL_JAR")
+      assert(null != sij)
+
+      And("The property AUDIT_IMPL_CLASS  must have been defined")
+      val aic = cfg.getProperty("AUDIT_IMPL_CLASS")
+      assert(null != sic)
+
+      And("The property DO_AUDIT  must have been defined")
+      val dau = cfg.getProperty("DO_AUDIT")
+      assert(null != dau)
+
+      And("The property SSL_CERTIFICATE  must have been defined")
+      val sc = cfg.getProperty("SSL_CERTIFICATE")
+      assert(null != sc)
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/ClusterConfigSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/ClusterConfigSpec.scala
@@ -1,0 +1,130 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+import org.json4s.jackson.JsonMethods._
+
+class ClusterConfigSpec extends CheckAPIPropSpec {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+
+  val loggerName = this.getClass.getName
+  val logger = Logger.getLogger(loggerName)
+
+  describe("Test CRUD operations on Cluster Config Objects") {
+    it ("Cluster Config Tests") {
+
+      //MetadataAPIImpl.SetLoggerLevel(Level.DEBUG)
+      //MetadataAPIImpl.SetLoggerLevel(Level.INFO)
+      logger.setLevel(Level.INFO)
+      //MdMgr.GetMdMgr.SetLoggerLevel(Level.TRACE)
+
+      And("The environment variable FATAFAT_HOME must be defined ")
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+      And("Check whether CONFIG_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("CONFIG_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few JSON config files in " + dirName);
+      val cfgFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".json"))
+      assert(0 != cfgFiles.length)
+
+      var fileList = List("ClusterConfig.json")
+      fileList.foreach(f1 => {
+	And("Add the Config From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  cfgFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	And("AddConfig first time from " + file.getPath)
+	var cfgStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.UploadConfig(cfgStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetAllCfgObjects to fetch all config objects")
+	res = MetadataAPIImpl.GetAllCfgObjects("JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetAllNodes to fetch the nodes")
+	res = MetadataAPIImpl.GetAllNodes("JSON")
+	res should include regex ("\"statusCode\" : 0")
+	logger.info(res)
+
+	And("GetAllAdapters to fetch the adapters")
+	res = MetadataAPIImpl.GetAllAdapters("JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetAllClusters to fetch the clusters")
+	res = MetadataAPIImpl.GetAllClusters("JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Check number of the nodes")
+	var nodes = MdMgr.GetMdMgr.Nodes
+	assert(nodes.size == 3)
+
+	And("Check number of the adapters")
+	var adapters = MdMgr.GetMdMgr.Adapters
+	assert(adapters.size == 4)
+
+	And("RemoveConfig API for the config that was just added")
+	res = MetadataAPIImpl.RemoveConfig(cfgStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Check number of the nodes after removing config")
+	nodes = MdMgr.GetMdMgr.Nodes
+	assert(nodes.size == 0)
+
+	And("Check number of the adapters after removing config")
+	adapters = MdMgr.GetMdMgr.Adapters
+	assert(adapters.size == 0)
+
+	And("AddConfig second time from " + file.getPath)
+	cfgStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.UploadConfig(cfgStr)
+	res should include regex ("\"statusCode\" : 0")
+      })
+      MetadataAPIImpl.shutdown
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/ContainerSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/ContainerSpec.scala
@@ -1,0 +1,166 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+import org.json4s.jackson.JsonMethods._
+
+class ContainerSpec extends CheckAPIPropSpec {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+  var objName:String = null
+  var contStr:String = null
+  var version:String = null
+  var o:Option[ContainerDef] = None
+
+  private val loggerName = this.getClass.getName
+  private val logger = Logger.getLogger(loggerName)
+
+
+  describe("Test CRUD operations on Container Objects") {
+    it ("Container Tests") {
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+      And("Check whether CONTAINER_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("CONTAINER_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few JSON container files in " + dirName);
+      val contFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".json"))
+      assert(0 != contFiles.length)
+
+      var fileList = List("CoughCodes.json","EnvCodes.json","DyspnoeaCodes.json","SmokeCodes.json","SputumCodes.json")
+      //var fileList = List("CoughCodes.json")
+      fileList.foreach(f1 => {
+	And("Add the Container From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  contFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	And("GetContainerDef API to fetch the container that may not even exist, check for statusCode of -1")
+	objName = f1.stripSuffix(".json").toLowerCase
+	version = "0000000000001000000"
+	res = MetadataAPIImpl.GetContainerDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : -1")
+
+	And("AddContainer first time from " + file.getPath)
+	contStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddContainer(contStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetContainerDef API to fetch the container that was just added")
+	res = MetadataAPIImpl.GetContainerDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("AddContainer second time from " + file.getPath + ",should result in error")
+	contStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddContainer(contStr,"JSON")
+	res should include regex ("\"statusCode\" : -1")
+
+	And("RemoveContainer API for the container that was just added")
+	res = MetadataAPIImpl.RemoveContainer(objName,1000000)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetContainerDef API to fetch the container that was just removed, should fail, check for statusCode of -1")
+	res = MetadataAPIImpl.GetContainerDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : -1")
+
+	And("AddContainer again to add Container from " + file.getPath)
+	contStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddContainer(contStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetContainerDef API to fetch  the container that was just added")
+	res = MetadataAPIImpl.GetContainerDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the container object from the cache")
+	o = MdMgr.GetMdMgr.Container("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Deactivate container that was just added")
+	MetadataAPIImpl.DeactivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Get the active container object from the cache after deactivating")
+	o = MdMgr.GetMdMgr.Container("system",objName, version.toLong, true)
+	assert(o == None )
+
+	And("Make sure the container object from the cache nolonger active ")
+	o = MdMgr.GetMdMgr.Container("system",objName, version.toLong, false)
+	assert(o != None )
+
+	And("Activate container that was just deactivated")
+	MetadataAPIImpl.ActivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Make sure the container object from the cache is active")
+	o = MdMgr.GetMdMgr.Container("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Update the container without changing version number, should fail ")
+	res = MetadataAPIImpl.UpdateContainer(contStr)
+	res should include regex ("\"statusCode\" : -1")
+
+	And("Clone the input json and update the version number to simulate a container for an update operation")
+	contStr = contStr.replaceFirst("01.00","01.01")
+	assert(contStr.indexOf("\"00.01.01\"") >= 0)
+	res = MetadataAPIImpl.UpdateContainer(contStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetContainerDef API to fetch the container that was just updated")
+	var newVersion = "0000000000001000001"
+	res = MetadataAPIImpl.GetContainerDef("system",objName,"JSON",newVersion)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the active container object from the cache after updating")
+	o = MdMgr.GetMdMgr.Container("system",objName, newVersion.toLong, true)
+	assert(o != None )
+
+	And("Make sure old(pre update version) container object nolonger active after the update")
+	o = MdMgr.GetMdMgr.Container("system",objName, version.toLong, true)
+	assert(o == None )
+
+      })
+
+      MetadataAPIImpl.shutdown
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/FunctionSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/FunctionSpec.scala
@@ -1,0 +1,142 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import com.ligadata.Serialize._
+
+import com.ligadata.fatafat.metadataload.MetadataLoad
+
+class FunctionSpec extends CheckAPIPropSpec{
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+  var resCode:Int = 0
+  var funcJsonStr:String = null
+
+  private val loggerName = this.getClass.getName
+  private val logger = Logger.getLogger(loggerName)
+
+  describe("Test CRUD operations on Function Objects") {
+    it ("Function Tests") {
+
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+
+      And("Check whether FUNCTION_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("FUNCTION_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few JSON function files in " + dirName);
+      val funcFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".json"))
+      assert(0 != funcFiles.length)
+
+      var fileList = List("SampleFunctions.json")
+      fileList.foreach(f1 => {
+	And("Add the Function From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  funcFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	And("Count the functions before adding sample functions")
+	var fcnKeys = MetadataAPIImpl.GetAllFunctionsFromCache(true)
+	var fcnKeyCnt = fcnKeys.length
+	assert(fcnKeyCnt > 0)
+
+	And("Call AddFunctions MetadataAPI Function to add Function from " + file.getPath)
+	var funcListJson = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddFunctions(funcListJson,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetAllFunctionDef API to fetch all the functions that were just added")
+	var rs1 = MetadataAPIImpl.GetAllFunctionDefs("JSON")
+	assert(rs1._1 != 0)
+	assert(rs1._2 != null)
+
+	And("Verify function count after adding sample functions")
+	fcnKeys = MetadataAPIImpl.GetAllFunctionsFromCache(true)
+	var fcnKeyCnt1 = fcnKeys.length
+	assert(fcnKeyCnt1 > 0)
+
+	And("SampleFunctions.json contains only 2 functions and newCount is greater by 2")
+	assert(fcnKeyCnt1 - fcnKeyCnt == 2)
+
+	And("Explictly parse the funcJsonStr to identify the functions that were just added")
+	implicit val jsonFormats: Formats = DefaultFormats
+	var json = parse(funcListJson)
+	logger.trace("Parsed the json : " + funcListJson)
+	val funcList = json.extract[FunctionList]
+	assert(funcList.Functions.length == 2)
+
+	And("RemoveFunction API for all the functions that were just added")
+	funcList.Functions.foreach(fcn => {
+	  res = MetadataAPIImpl.RemoveFunction(fcn.NameSpace, fcn.Name, fcn.Version.toLong)
+	  res should include regex ("\"statusCode\" : 0")
+	})
+
+	And("Check whether all the functions are removed")
+	funcList.Functions.foreach(fcn => {
+	  res = MetadataAPIImpl.GetFunctionDef(fcn.NameSpace, fcn.Name, "JSON",fcn.Version)
+	  res should include regex("\"statusCode\" : 0")
+	})
+
+	And("Verify function count after removing the sample functions")
+	fcnKeys = MetadataAPIImpl.GetAllFunctionsFromCache(true)
+	fcnKeyCnt1 = fcnKeys.length
+	assert(fcnKeyCnt1 > 0)
+	assert(fcnKeyCnt1 - fcnKeyCnt == 0)
+
+	And("AddFunctions MetadataAPI Function again to add Function from " + file.getPath)
+	res = MetadataAPIImpl.AddFunctions(funcListJson,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	funcList.Functions.foreach(fcn => {
+	  var o = MdMgr.GetMdMgr.Functions(fcn.NameSpace,fcn.Name,true,true)
+	  assert(o != None )
+	})
+      })
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/MessageSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/MessageSpec.scala
@@ -1,0 +1,142 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+
+import org.json4s.jackson.JsonMethods._
+
+class MessageSpec extends CheckAPIPropSpec{
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+
+  describe("Test CRUD operations on Message Objects") {
+    it ("Message Tests") {
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+      And("Check whether MESSAGE_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("MESSAGE_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few JSON message files in " + dirName);
+      val msgFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".json"))
+      assert(0 != msgFiles.length)
+
+      var fileList = List("outpatientclaim.json","inpatientclaim.json","hl7.json","beneficiary.json")
+      //var fileList = List("outpatientclaim.json")
+      fileList.foreach(f1 => {
+	And("Add the Message From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  msgFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	And("AddMessage first time from " + file.getPath)
+	var msgStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddMessage(msgStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetMessageDef API to fetch the message that was just added")
+	var objName = f1.stripSuffix(".json").toLowerCase
+	var version = "0000000000001000000"
+	res = MetadataAPIImpl.GetMessageDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("RemoveMessage API for the message that was just added")
+	res = MetadataAPIImpl.RemoveMessage(objName,1000000)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("AddMessage again to add Message from " + file.getPath)
+	msgStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddMessage(msgStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetMessageDef API to fetch  the message that was just added")
+	objName = f1.stripSuffix(".json").toLowerCase
+	res = MetadataAPIImpl.GetMessageDef("system",objName,"JSON",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the message object from the cache")
+	var o = MdMgr.GetMdMgr.Message("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Deactivate message that was just added")
+	MetadataAPIImpl.DeactivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Get the active message object from the cache after deactivating")
+	o = MdMgr.GetMdMgr.Message("system",objName, version.toLong, true)
+	assert(o == None )
+
+	And("Make sure the message object from the cache nolonger active ")
+	o = MdMgr.GetMdMgr.Message("system",objName, version.toLong, false)
+	assert(o != None )
+
+	And("Activate message that was just deactivated")
+	MetadataAPIImpl.ActivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Make sure the message object from the cache is active")
+	o = MdMgr.GetMdMgr.Message("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Clone the input json and update the version number to simulate a message for an update operation")
+	msgStr = msgStr.replaceFirst("01.00","01.01")
+	assert(msgStr.indexOf("\"00.01.01\"") >= 0)
+	res = MetadataAPIImpl.UpdateMessage(msgStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetMessageDef API to fetch the message that was just updated")
+	var newVersion = "0000000000001000001"
+	res = MetadataAPIImpl.GetMessageDef("system",objName,"JSON",newVersion)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the active message object from the cache after updating")
+	o = MdMgr.GetMdMgr.Message("system",objName, newVersion.toLong, true)
+	assert(o != None )
+
+	And("Make sure old(pre update version) message object nolonger active after the update")
+	o = MdMgr.GetMdMgr.Message("system",objName, version.toLong, true)
+	assert(o == None )
+
+      })
+    
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/MiscFuncSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/MiscFuncSpec.scala
@@ -1,0 +1,121 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io._
+
+import sys.process._
+import org.apache.log4j._
+import org.json4s.jackson.JsonMethods._
+
+class MiscFuncSpec extends CheckAPIPropSpec {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+
+  val loggerName = this.getClass.getName
+  val logger = Logger.getLogger(loggerName)
+
+  describe("Test Other misc operations ") {
+    it ("Misc tests not covered by other specs") {
+
+      //MetadataAPIImpl.SetLoggerLevel(Level.DEBUG)
+      //MetadataAPIImpl.SetLoggerLevel(Level.INFO)
+      logger.setLevel(Level.INFO)
+      //MdMgr.GetMdMgr.SetLoggerLevel(Level.TRACE)
+
+      var fh = System.getenv("FATAFAT_HOME")
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      var fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+      var cfg = MetadataAPIImpl.GetMetadataAPIConfig
+      assert(null != cfg)
+
+      And("Test Authorization functions")
+      And("The property DO_AUTH  must have been defined")
+      var da = cfg.getProperty("DO_AUTH")
+      assert(null != da)
+      
+      And("checkAuth with correct user and password")
+      var chk = MetadataAPIImpl.checkAuth(Some("lonestarr"),Some("vespa"),Some("goodguy"),"read")
+      assert(chk == true)
+
+      And("checkAuth with wrong user")
+      chk = MetadataAPIImpl.checkAuth(Some("lonestarr1"),Some("vespa"),Some("goodguy"),"read")
+      assert(chk == false)
+
+      And("checkAuth with wrong password")
+      chk = MetadataAPIImpl.checkAuth(Some("lonestarr"),Some("vespa1"),Some("goodguy"),"read")
+      assert(chk == false)
+
+      And("checkAuth for admin user")
+      chk = MetadataAPIImpl.checkAuth(Some("root"),Some("secret"),Some("admin"),"adminprivileges")
+      assert(chk == true)
+
+      And("Audit Functions")
+      And("The property DO_AUDIT  must have been defined")
+      da = cfg.getProperty("DO_AUDIT")
+      assert(null != da)
+
+      And("logAuditRec ")
+      noException should be thrownBy {
+	MetadataAPIImpl.logAuditRec(Some("lonestarr"),Some("write"),"GetContainerDef","system.coughcodes.000000100000000000","true","12345657","system.coughcodes.000000100000000000")
+      }
+
+      And("getAuditRec ")
+      res = MetadataAPIImpl.getAuditRec(new Date((new Date).getTime() - 1500 * 60000),null,null,null,null)
+      assert(res != null)
+      res should include regex("\"Action\" : \"GetContainerDef\"")
+      res should include regex("\"UserOrRole\" : \"lonestarr\"")
+      res should include regex("\"Status\" : \"true\"")
+      res should include regex("\"ObjectAccessed\" : \"system.coughcodes.000000100000000000\"")
+      res should include regex("\"ActionResult\" : \"system.coughcodes.000000100000000000\"")
+
+      And("GetTranId returns last transactionId used as long")
+      var l = MetadataAPIImpl.GetTranId
+      assert(l > 0)
+
+      And("GetNewTranId returns a long")
+      var l1 = MetadataAPIImpl.GetNewTranId
+      assert(l + 1 == l1)
+
+      And("PutTranId updates the tranId")
+      noException should be thrownBy {
+	MetadataAPIImpl.PutTranId(l1)
+      }
+
+      And("GetTranId after last update of transactionId")
+      var l2 = MetadataAPIImpl.GetTranId
+      assert(l2 == l1)
+
+      And("GetJarAsArrayOfBytes with invalid jarName as input")
+      var ex = the [FileNotFoundException] thrownBy {
+	var aob = MetadataAPIImpl.GetJarAsArrayOfBytes("unknown_junk.jar")
+      }
+      ex.getMessage should include regex("Jar file \\(unknown_junk.jar\\) is not found")
+
+      And("GetJarAsArrayOfBytes with valid jarName as input")
+      noException should be thrownBy {
+	var sampleJarFile = System.getenv("FATAFAT_HOME") + "/lib/system/fatafatbase_2.10-1.0.jar"
+	var aob = MetadataAPIImpl.GetJarAsArrayOfBytes(sampleJarFile)
+	fl = new File(sampleJarFile)
+        assert(aob.length == fl.length())
+      }
+      MetadataAPIImpl.shutdown
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/ModelSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/ModelSpec.scala
@@ -1,0 +1,164 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+
+import org.json4s.jackson.JsonMethods._
+
+class ModelSpec extends CheckAPIPropSpec {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+
+
+  
+  /**
+   * extractNameFromPMML - pull the Application name="xxx" from the PMML doc and construct
+   *                       a name  string from it, cloned from APIService.scala
+   */
+  def extractNameFromPMML (pmmlObj: String): String = {
+    var firstOccurence: String = "unknownModel"
+    val pattern = """Application[ ]*name="([^ ]*)"""".r
+    val allMatches = pattern.findAllMatchIn(pmmlObj)
+    allMatches.foreach( m => {
+      if (firstOccurence.equalsIgnoreCase("unknownModel")) {
+      firstOccurence = (m.group(1))
+      }
+    })
+    return firstOccurence
+  }
+
+
+  describe("Test CRUD operations on Model Objects") {
+    it ("Model Tests") {
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+
+      And("Check whether MODEL_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("MODEL_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few pmml model files in " + dirName);
+      val modFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".xml"))
+      assert(0 != modFiles.length)
+
+      var fileList = List("COPDv1.xml")
+      fileList.foreach(f1 => {
+	And("Add the Model From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  modFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	And("Call AddModel MetadataAPI Function to add Model from " + file.getPath)
+	var modStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddModel(modStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetModelDef API to fetch the model that was just added")
+	// Unable to use fileName to identify the name of the object
+	// Use this function to extract the name of the model
+	var objName = extractNameFromPMML(modStr).toLowerCase
+	assert(objName != "unknownModel")
+
+	var version = "0000000000001000000"
+	res = MetadataAPIImpl.GetModelDef("system",objName,"XML",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("RemoveModel API for the model that was just added")
+	res = MetadataAPIImpl.RemoveModel(objName,1000000)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("AddModel again to add Model from " + file.getPath)
+	//modStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddModel(modStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetModelDef API to fetch  the model that was just added")
+	//objName = f1.stripSuffix(".json").toLowerCase
+	res = MetadataAPIImpl.GetModelDef("system",objName,"XML",version)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the model object from the cache")
+	var o = MdMgr.GetMdMgr.Model("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Deactivate model that was just added")
+	MetadataAPIImpl.DeactivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Get the active model object from the cache after deactivating")
+	o = MdMgr.GetMdMgr.Model("system",objName, version.toLong, true)
+	assert(o == None )
+
+	And("Make sure the model object from the cache nolonger active ")
+	o = MdMgr.GetMdMgr.Model("system",objName, version.toLong, false)
+	assert(o != None )
+
+	And("Activate model that was just deactivated")
+	MetadataAPIImpl.ActivateObject(o.get.asInstanceOf[BaseElemDef])
+
+	And("Make sure the model object from the cache is active")
+	o = MdMgr.GetMdMgr.Model("system",objName, version.toLong, true)
+	assert(o != None )
+
+	And("Clone the input json and update the version number to simulate a model for an update operation")
+	modStr = modStr.replaceFirst("01.00","01.01")
+	assert(modStr.indexOf("\"00.01.01\"") >= 0)
+	res = MetadataAPIImpl.UpdateModel(modStr)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("GetModelDef API to fetch the model that was just updated")
+	var newVersion = "0000000000001000001"
+	res = MetadataAPIImpl.GetModelDef("system",objName,"XML",newVersion)
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Get the active model object from the cache after updating")
+	o = MdMgr.GetMdMgr.Model("system",objName, newVersion.toLong, true)
+	assert(o != None )
+
+	And("Make sure old(pre update version) model object nolonger active after the update")
+	o = MdMgr.GetMdMgr.Model("system",objName, version.toLong, true)
+	assert(o == None )
+
+      })
+    }
+  }
+}

--- a/trunk/MetadataAPI/src/test/scala/TestAllSuites.scala
+++ b/trunk/MetadataAPI/src/test/scala/TestAllSuites.scala
@@ -1,0 +1,63 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+
+class TestAllSuites extends FunSuite  {
+
+  val loggerName = this.getClass.getName
+  val logger = Logger.getLogger(loggerName)
+
+  var ts0 = new CheckAPIPropSpec
+  ts0.execute()
+
+  //And("Truncate database Before Starting the test")
+  val db = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("DATABASE")
+  assert(null != db)
+  MetadataAPIImpl.OpenDbStore(db)
+  assert(null != MetadataAPIImpl.GetMetadataStore)
+  MetadataAPIImpl.GetMetadataStore.TruncateStore
+  assert(null != MetadataAPIImpl.GetConfigStore)
+  MetadataAPIImpl.GetConfigStore.TruncateStore
+  assert(null != MetadataAPIImpl.GetJarStore)
+  MetadataAPIImpl.GetJarStore.TruncateStore
+  assert(null != MetadataAPIImpl.GetTransStore)
+  MetadataAPIImpl.GetTransStore.TruncateStore
+  MetadataAPIImpl.CloseDbStore
+      
+  
+  //And("Container objects..")
+  var ts1 = new ContainerSpec
+  ts1.execute()
+  //And("Message objects..")
+  var ts2 = new MessageSpec
+  ts2.execute()
+  //And("Model objects..")
+  var ts3 = new ModelSpec
+  ts3.execute()
+  //And("Type objects..")
+  var ts4 = new TypeSpec
+  ts4.execute()
+  //And("Function objects..")
+  var ts5 = new FunctionSpec
+  ts5.execute()
+  //And("ClusterConfig objects..")
+  var ts6 = new ClusterConfigSpec
+  ts6.execute()
+  //And("MiscFuncSpec..")
+  var ts7 = new MiscFuncSpec
+  ts7.execute()
+}

--- a/trunk/MetadataAPI/src/test/scala/TypeSpec.scala
+++ b/trunk/MetadataAPI/src/test/scala/TypeSpec.scala
@@ -1,0 +1,161 @@
+package com.ligadata.metadataapitest
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.MetadataAPI._
+import com.ligadata.fatafat.metadata._
+import com.ligadata.fatafat.metadata.MdMgr._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.Date
+import java.io.File
+
+import sys.process._
+import org.apache.log4j._
+
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import com.ligadata.Serialize._
+
+class TypeSpec extends CheckAPIPropSpec {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var apiResKey:String = "\"statusCode\" : 0"
+
+  private val loggerName = this.getClass.getName
+  private val logger = Logger.getLogger(loggerName)
+
+  describe("Test CRUD operations on Type Objects") {
+    it ("Type Tests") {
+
+      //logger.setLevel(Level.TRACE)
+      //MetadataAPIImpl.SetLoggerLevel(Level.TRACE)
+      //JsonSerializer.SetLoggerLevel(Level.TRACE)
+
+      var fh = System.getenv("FATAFAT_HOME")
+      assert(fh != null)
+
+      var myConfigFile = fh + "/input/application1/metadata/config/MetadataAPIConfig.properties"
+      And("The configfile " + myConfigFile + " should exist ")
+      val fl = new File(myConfigFile)
+      assert(fl.exists == true)
+
+      And("Initialize everything including related to MetadataAPI execution")
+      MetadataAPIImpl.InitMdMgrFromBootStrap(myConfigFile)
+
+
+      And("Check whether TYPE_FILES_DIR defined as property")
+      var dirName = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("TYPE_FILES_DIR")
+      assert(null != dirName)
+
+      And("Check Directory Path")
+      val iFile = new File(dirName)
+      assert(true == iFile.exists)
+
+      And("Check whether " + dirName + " is a directory ")
+      assert(true == iFile.isDirectory)
+
+      And("Make sure there are few JSON type files in " + dirName);
+      val typeFiles = new java.io.File(dirName).listFiles.filter(_.getName.endsWith(".json"))
+      assert(0 != typeFiles.length)
+
+      var fileList = List("SampleTypes.json")
+      fileList.foreach(f1 => {
+	And("Add the Type From " + f1)
+	And("Make Sure " + f1 + " exist")
+	var exists = false
+	var file: java.io.File = null
+	breakable{
+	  typeFiles.foreach(f2 => {
+	    if( f2.getName() == f1 ){
+	      exists = true
+	      file = f2
+	      break
+	    }
+	  })
+	}
+	assert(true == exists)
+
+	var typKeys = MetadataAPIImpl.GetAllTypesFromCache(true)
+	assert(typKeys.length != 0)
+
+	And("Call AddTypes MetadataAPI Type to add Type from " + file.getPath)
+	var typeStr = Source.fromFile(file).mkString
+	res = MetadataAPIImpl.AddTypes(typeStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	var resCode:Int = 0
+	And("GetAllTypes API to fetch all the types that were just added as json string")
+	var typeJsonStr1 = MetadataAPIImpl.GetAllTypes("JSON")
+	assert(typeJsonStr1 != null)
+	
+	And("verify the type count after adding new types")
+	var typKeys1 = MetadataAPIImpl.GetAllTypesFromCache(true)
+	assert(typKeys1.length != 0)
+	assert(typKeys1.length - typKeys.length == 5)
+
+	And("RemoveType API for the types that were just added")
+	implicit val jsonFormats: Formats = DefaultFormats
+	var json = parse(typeStr)
+	//logger.trace("Parsed the json : " + typeStr)
+	var typesAdded = json.extract[TypeDefList]
+
+	//var typesAdded = JsonSerializer.parseTypeList(typeStr,"JSON")
+	assert(typesAdded.Types.length == 5)
+
+	typesAdded.Types.foreach(typ => {
+	  res = MetadataAPIImpl.RemoveType(typ.NameSpace, typ.Name, typ.Version.toLong)
+	  res should include regex ("\"statusCode\" : 0")
+	})
+
+	And("verify the type count after removing new types")
+	typKeys1 = MetadataAPIImpl.GetAllTypesFromCache(true)
+	assert(typKeys1.length != 0)
+	assert(typKeys.length - typKeys1.length == 0)
+
+	And("Check whether all the types are removed")
+	typesAdded.Types.foreach(typ => {
+	  res = MetadataAPIImpl.GetTypeDef(typ.NameSpace, typ.Name, "JSON", typ.Version)
+	  res should include regex ("\"statusCode\" : 0")
+	})
+
+
+	And("AddTypes again ")
+	res = MetadataAPIImpl.AddTypes(typeStr,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+
+	And("Check GetType function")
+	var typeObjList = new Array[BaseTypeDef](0)
+	typesAdded.Types.foreach(typ => {
+	  var o = MetadataAPIImpl.GetType(typ.NameSpace, typ.Name, typ.Version,"JSON")
+	  assert(o != None )
+	  typeObjList = typeObjList :+ o.get
+	})
+	assert(typeObjList.length == typesAdded.Types.length)
+
+	And("Generate Json String from typeList generated using GetType function")
+	var typeJsonStr2 = JsonSerializer.SerializeObjectListToJson("Types",typeObjList)
+	//logger.trace(typeJsonStr2)
+
+	And("RemoveType API for the types that were just added")
+	var json1 = parse(typeJsonStr2)
+	logger.trace("Parsed the json : " + typeJsonStr2)
+	var typesAdded1 = json1.extract[TypeDefList]
+	assert(typesAdded1.Types.length == 5)
+	typesAdded1.Types.foreach(typ => {
+	  logger.trace("Remove the type " + Array(typ.NameSpace,typ.Name,typ.Version).mkString("."))
+	  res = MetadataAPIImpl.RemoveType(typ.NameSpace, typ.Name, typ.Version.toLong)
+	  res should include regex ("\"statusCode\" : 0")
+	})
+
+	And("AddTypes again this time use the json string generated by JsonSerializer")
+	res = MetadataAPIImpl.AddTypes(typeJsonStr2,"JSON")
+	res should include regex ("\"statusCode\" : 0")
+      })
+    }
+  }
+}

--- a/trunk/Utils/Serialize/src/main/scala/com/ligadata/Serialize/JsonSerializer.scala
+++ b/trunk/Utils/Serialize/src/main/scala/com/ligadata/Serialize/JsonSerializer.scala
@@ -723,6 +723,17 @@ object JsonSerializer {
                       ("DependantJars"   -> o.CheckAndGetDependencyJarNames.toList))
           pretty(render(json))
         }
+        case o:FunctionDef => {
+          val json = (("ObjectType"      -> "FunctionDef") ~
+                      ("Operation"       -> operation) ~
+                      ("NameSpace"       -> o.nameSpace) ~
+                      ("Name"            -> o.name) ~
+                      ("Version"         -> o.ver) ~
+                      ("PhysicalName"    -> o.physicalName) ~
+                      ("JarName"         -> o.jarName) ~
+                      ("DependantJars"   -> o.CheckAndGetDependencyJarNames.toList))
+          pretty(render(json))
+        }
         case o:ArrayTypeDef => {
           val json = (("ObjectType"      -> "ArrayTypeDef") ~
                       ("Operation"       -> operation) ~
@@ -769,6 +780,17 @@ object JsonSerializer {
         }
         case o:MapTypeDef => {
           val json = (("ObjectType"      -> "MapTypeDef") ~
+                      ("Operation"       -> operation) ~
+                      ("NameSpace"       -> o.nameSpace) ~
+                      ("Name"            -> o.name) ~
+                      ("Version"         -> o.ver) ~
+                      ("PhysicalName"    -> o.physicalName) ~
+                      ("JarName"         -> o.jarName) ~
+                      ("DependantJars"   -> o.CheckAndGetDependencyJarNames.toList))
+          pretty(render(json))
+        }
+        case o:HashMapTypeDef => {
+          val json = (("ObjectType"      -> "HashMapTypeDef") ~
                       ("Operation"       -> operation) ~
                       ("NameSpace"       -> o.nameSpace) ~
                       ("Name"            -> o.name) ~
@@ -1034,7 +1056,7 @@ object JsonSerializer {
 		     ("Name" -> o.name) ~
 		     ("TypeTypeName" -> ObjTypeType.asString(o.tTypeType) ) ~
 		     ("TypeNameSpace" -> MdMgr.sysNS ) ~
-		     ("TypeName" -> o.name ) ~
+		     ("TypeName" -> o.physicalName ) ~
 		     ("PhysicalName" -> o.physicalName ) ~
 		     ("Version" -> MdMgr.Pad0s2Version(o.ver)) ~
 		     ("JarName" -> o.jarName) ~

--- a/trunk/Utils/ZooKeeper/CuratorLeaderLatch/src/main/resources/log4j.properties
+++ b/trunk/Utils/ZooKeeper/CuratorLeaderLatch/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
  # Log levels
-log4j.rootLogger=DEBUG,CONSOLE,R
+log4j.rootLogger=WARN,CONSOLE,R
 # Appender Configuration
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 # Pattern to output the caller's file name and line number


### PR DESCRIPTION
I have made some minor changes in MetadataAPIImpl. Those changes has to do with crud operations with types and functions. Pokuri implemented some of these changes in the branch he delivered to the bank. You can choose to ignore them during merge.