### PR TITLE
Fatafat 257

### DIFF
--- a/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/IbmMqProducer.scala
+++ b/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/IbmMqProducer.scala
@@ -92,36 +92,42 @@ class IbmMqProducer(val inputConfig: AdapterConfiguration, cntrAdapter: Counters
     case jmsex: Exception => {
       printFailure(jmsex)
       val stackTrace = StackTrace.ThrowableTraceString(jmsex)
-      LOG.debug("StackTrace:"+stackTrace)}
+      LOG.debug("StackTrace:" + stackTrace)
+    }
   }
 
-  override def send(message: String, partKey: String): Unit = {
+  // To send an array of messages. messages.size should be same as partKeys.size
+  override def send(messages: Array[Array[Byte]], partKeys: Array[Array[Byte]]): Unit = {
+    if (messages.size != partKeys.size) {
+      LOG.error("Message and Partition Keys hould has same number of elements. Message has %d and Partition Keys has %d".format(messages.size, partKeys.size))
+      return
+    }
+    if (messages.size == 0) return
+
     try {
-      // Do we need text Message or Bytes Message?
-      if (qc.msgType == com.ligadata.AdaptersConfiguration.MessageType.fByteArray) {
-        val outmessage = session.createBytesMessage()
-        outmessage.writeBytes(message.getBytes)
-        outmessage.setStringProperty("ContentType", qc.content_type)
-        producer.send(outmessage)
-      } else { // By default we are taking (qc.msgType == com.ligadata.AdaptersConfiguration.MessageType.fText)
-        val outmessage = session.createTextMessage(new String(message))
-        outmessage.setStringProperty("ContentType", qc.content_type)
-        producer.send(outmessage)
-      }
-      val key = Category + "/" + qc.Name + "/evtCnt"
-      cntrAdapter.addCntr(key, 1) // for now adding each row
+      // Op is not atomic
+      messages.foreach(message => {
+        // Do we need text Message or Bytes Message?
+        if (qc.msgType == com.ligadata.AdaptersConfiguration.MessageType.fByteArray) {
+          val outmessage = session.createBytesMessage()
+          outmessage.writeBytes(message)
+          outmessage.setStringProperty("ContentType", qc.content_type)
+          producer.send(outmessage)
+        } else { // By default we are taking (qc.msgType == com.ligadata.AdaptersConfiguration.MessageType.fText)
+          val outmessage = session.createTextMessage(new String(message))
+          outmessage.setStringProperty("ContentType", qc.content_type)
+          producer.send(outmessage)
+        }
+        val key = Category + "/" + qc.Name + "/evtCnt"
+        cntrAdapter.addCntr(key, 1) // for now adding each row
+      })
     } catch {
       case jmsex: Exception => {
         printFailure(jmsex)
         val stackTrace = StackTrace.ThrowableTraceString(jmsex)
-      LOG.debug("StackTrace:"+stackTrace)
+        LOG.debug("StackTrace:" + stackTrace)
       }
     }
-  }
-
-  override def send(message: Array[Byte], partKey: Array[Byte]): Unit = {
-    send(new String(message), new String(partKey))
-    // If we are going to send ByteArray message, we need to switch sending to here.
   }
 
   override def Shutdown(): Unit = {

--- a/trunk/InputOutputAdapters/InputOutputAdapterBase/src/main/scala/com/ligadata/InputOutputAdapterInfo/InputOutputAdapterInfo.scala
+++ b/trunk/InputOutputAdapters/InputOutputAdapterBase/src/main/scala/com/ligadata/InputOutputAdapterInfo/InputOutputAdapterInfo.scala
@@ -82,8 +82,16 @@ trait OutputAdapterObj {
 trait OutputAdapter {
   val inputConfig: AdapterConfiguration // Configuration
 
-  def send(message: String, partKey: String): Unit
-  def send(message: Array[Byte], partKey: Array[Byte]): Unit
+  def send(message: String, partKey: String): Unit = send(Array(message.getBytes("UTF8")), Array(partKey.getBytes("UTF8")))
+
+  def send(message: Array[Byte], partKey: Array[Byte]): Unit = send(Array(message), Array(partKey))
+
+  // To send an array of messages. messages.size should be same as partKeys.size
+  def send(messages: Array[String], partKeys: Array[String]): Unit = send(messages.map(m => m.getBytes("UTF8")), partKeys.map(k => k.getBytes("UTF8")))
+  
+  // To send an array of messages. messages.size should be same as partKeys.size
+  def send(messages: Array[Array[Byte]], partKeys: Array[Array[Byte]]): Unit
+  
   def Shutdown: Unit
   def Category = "Output"
 }

--- a/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/KafkaProducer.scala
+++ b/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/KafkaProducer.scala
@@ -77,7 +77,7 @@ class KafkaProducer(val inputConfig: AdapterConfiguration, cntrAdapter: Counters
     try {
       val keyMessages = new ArrayBuffer[KeyedMessage[Array[Byte], Array[Byte]]](messages.size)
       for (i <- 0 until messages.size) {
-        keyMessages += new KeyedMessage(qc.topic, messages(i), partKeys(i))
+        keyMessages += new KeyedMessage(qc.topic, partKeys(i), messages(i))
       }
       producer.send(keyMessages: _*) // Thinking this op is atomic for (can write multiple partitions into one queue, but don't know whether it is atomic per partition in the queue).
       val key = Category + "/" + qc.Name + "/evtCnt"

--- a/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/KafkaProducer.scala
+++ b/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/src/main/scala/com/ligadata/OutputAdapters/KafkaProducer.scala
@@ -24,6 +24,7 @@ import org.apache.log4j.Logger
 import com.ligadata.InputOutputAdapterInfo.{ AdapterConfiguration, OutputAdapter, OutputAdapterObj, CountersAdapter }
 import com.ligadata.AdaptersConfiguration.KafkaQueueAdapterConfiguration
 import com.ligadata.Exceptions.StackTrace
+import scala.collection.mutable.ArrayBuffer
 
 object KafkaProducer extends OutputAdapterObj {
   def CreateOutputAdapter(inputConfig: AdapterConfiguration, cntrAdapter: CountersAdapter): OutputAdapter = new KafkaProducer(inputConfig, cntrAdapter)
@@ -64,20 +65,29 @@ class KafkaProducer(val inputConfig: AdapterConfiguration, cntrAdapter: Counters
   // props.put("socket.receive.buffer", bufferMemory.toString)
   props.put("client.id", clientId)
 
-  val producer = new Producer[AnyRef, AnyRef](new ProducerConfig(props)) // Not closing this producer at this moment
+  val producer = new Producer[Array[Byte], Array[Byte]](new ProducerConfig(props)) // Not closing this producer at this moment
 
-  override def send(message: String, partKey: String): Unit = send(message.getBytes("UTF8"), partKey.getBytes("UTF8"))
-
-  override def send(message: Array[Byte], partKey: Array[Byte]): Unit = {
+  // To send an array of messages. messages.size should be same as partKeys.size
+  override def send(messages: Array[Array[Byte]], partKeys: Array[Array[Byte]]): Unit = {
+    if (messages.size != partKeys.size) {
+      LOG.error("Message and Partition Keys hould has same number of elements. Message has %d and Partition Keys has %d".format(messages.size, partKeys.size))
+      return
+    }
+    if (messages.size == 0) return
     try {
-      producer.send(new KeyedMessage(qc.topic, partKey, message))
+      val keyMessages = new ArrayBuffer[KeyedMessage[Array[Byte], Array[Byte]]](messages.size)
+      for (i <- 0 until messages.size) {
+        keyMessages += new KeyedMessage(qc.topic, messages(i), partKeys(i))
+      }
+      producer.send(keyMessages: _*) // Thinking this op is atomic for (can write multiple partitions into one queue, but don't know whether it is atomic per partition in the queue).
       val key = Category + "/" + qc.Name + "/evtCnt"
-      cntrAdapter.addCntr(key, 1) // for now adding each row
+      cntrAdapter.addCntr(key, messages.size) // for now adding rows
     } catch {
       case e: Exception => {
         LOG.error("Failed to send :" + e.getMessage)
       }
     }
+
   }
 
   override def Shutdown(): Unit = {

--- a/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
+++ b/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
@@ -250,17 +250,17 @@ trait EnvContext {
   def containsAll(transId: Long, containerName: String, partKeys: Array[List[String]], primaryKeys: Array[List[String]]): Boolean //partKeys.size should be same as primaryKeys.size
 
   // Adapters Keys & values
-  def setAdapterUniqueKeyValue(transId: Long, key: String, value: String, outputResults: List[(String, String)]): Unit
-  def getAdapterUniqueKeyValue(transId: Long, key: String): (Long, String, List[(String, String)])
+  def setAdapterUniqueKeyValue(transId: Long, key: String, value: String, outputResults: List[(String, String, String)]): Unit
+  def getAdapterUniqueKeyValue(transId: Long, key: String): (Long, String, List[(String, String, String)])
 /*
   def getAllIntermediateStatusInfo: Array[(String, (String, Int, Int))] // Get all Status information from intermediate table. No Transaction required here.
   def getIntermediateStatusInfo(keys: Array[String]): Array[(String, (String, Int, Int))] // Get Status information from intermediate table for given keys. No Transaction required here.
 */
   def getAllAdapterUniqKvDataInfo(keys: Array[String]): Array[(String, (Long, String))] // Get Status information from Final table. No Transaction required here.
 
-  def getAllIntermediateCommittingInfo: Array[(String, (Long, String, List[(String, String)]))] // Getting intermediate committing information. Once we commit we don't have this, because we remove after commit
+  def getAllIntermediateCommittingInfo: Array[(String, (Long, String, List[(String, String, String)]))] // Getting intermediate committing information. Once we commit we don't have this, because we remove after commit
 
-  def getAllIntermediateCommittingInfo(keys: Array[String]): Array[(String, (Long, String, List[(String, String)]))] // Getting intermediate committing information.
+  def getAllIntermediateCommittingInfo(keys: Array[String]): Array[(String, (Long, String, List[(String, String, String)]))] // Getting intermediate committing information.
 
   def removeCommittedKey(transId: Long, key: String): Unit
   def removeCommittedKeys(keys: Array[String]): Unit
@@ -270,7 +270,8 @@ trait EnvContext {
   def getModelsResult(transId: Long, key: List[String]): scala.collection.mutable.Map[String, SavedMdlResult]
 
   // Final Commit for the given transaction
-  def commitData(transId: Long, key: String, value: String, outputResults: List[(String, String)]): Unit
+  // outputResults has AdapterName, PartitionKey & Message
+  def commitData(transId: Long, key: String, value: String, outputResults: List[(String, String, String)]): Unit
 
   // Save State Entries on local node & on Leader
   def PersistLocalNodeStateEntries: Unit

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
@@ -46,7 +46,8 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
 
   val xform = new TransformMessageData
   val engine = new LearningEngine(input, curPartitionKey)
-  var cntr: Long = 0
+  val allOutputAdaptersNames = if (kamanjaCallerCtxt.outputAdapters != null) kamanjaCallerCtxt.outputAdapters.map(o => o.inputConfig.Name.toLowerCase) else Array[String]()
+  val allOuAdapters = if (kamanjaCallerCtxt.outputAdapters != null) kamanjaCallerCtxt.outputAdapters.map(o => (o.inputConfig.Name.toLowerCase, o)).toMap else Map[String, OutputAdapter]()
   def execute(data: Array[Byte], format: String, uniqueKey: PartitionUniqueRecordKey, uniqueVal: PartitionUniqueRecordValue, readTmNanoSecs: Long, readTmMilliSecs: Long, ignoreOutput: Boolean, associatedMsg: String, delimiters: DataDelimiters): Unit = {
     try {
       val uk = uniqueKey.Serialize
@@ -54,7 +55,7 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
       val transId = transService.getNextTransId
       LOG.debug("Processing uniqueKey:%s, uniqueVal:%s, Datasize:%d".format(uk, uv, data.size))
 
-      var outputResults = ArrayBuffer[(String, String)]() // Adapter/Queue name & output message 
+      var outputResults = ArrayBuffer[(String, String, String)]() // Adapter/Queue name, Partition Key & output message 
 
       try {
         val transformStartTime = System.nanoTime
@@ -64,7 +65,7 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
         val totalXformedMsgs = xformedmsgs.size
         xformedmsgs.foreach(xformed => {
           xformedMsgCntr += 1
-          var output = engine.execute(transId, data, xformed._1, xformed._2, xformed._3, kamanjaCallerCtxt.envCtxt, readTmNanoSecs, readTmMilliSecs, uk, uv, xformedMsgCntr, totalXformedMsgs, ignoreOutput)
+          var output = engine.execute(transId, data, xformed._1, xformed._2, xformed._3, kamanjaCallerCtxt.envCtxt, readTmNanoSecs, readTmMilliSecs, uk, uv, xformedMsgCntr, totalXformedMsgs, ignoreOutput, allOutputAdaptersNames)
           if (output != null) {
             outputResults ++= output
           }
@@ -109,18 +110,16 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
             }
           }
         }
-        
-        val sendOutStartTime = System.nanoTime
-        if (outputResults != null && kamanjaCallerCtxt.outputAdapters != null) {
-          // Not yet checking for Adapter Name matches
-          outputResults.foreach(adapteroutput => {
-            kamanjaCallerCtxt.outputAdapters.foreach(o => {
-              o.send(adapteroutput._2, cntr.toString)
-              cntr += 1
-            })
-          })
-        }
 
+        val sendOutStartTime = System.nanoTime
+        val outputs = outputResults.groupBy(_._1)
+
+        outputs.foreach(output => {
+          val oadap = allOuAdapters.getOrElse(output._1, null)
+          if (oadap != null) {
+            oadap.send(output._2.map(out => out._3.getBytes("UTF8")).toArray, output._2.map(out => out._2.getBytes("UTF8")).toArray)
+          }
+        })
         if (KamanjaConfiguration.waitProcessingTime > 0 && KamanjaConfiguration.waitProcessingSteps(3)) {
           try {
             LOG.debug("Started Waiting in Step 3 (before removing sent data) for Message:" + dispMsg)
@@ -133,7 +132,7 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
             }
           }
         }
-                
+
         kamanjaCallerCtxt.envCtxt.removeCommittedKey(transId, uk)
         LOG.info(ManagerUtils.getComponentElapsedTimeStr("SendResults", uv, readTmNanoSecs, sendOutStartTime))
 

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
@@ -116,6 +116,7 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
 
         outputs.foreach(output => {
           val oadap = allOuAdapters.getOrElse(output._1, null)
+          LOG.debug("Sending data => " + output._2.map(o => o._1 + "~~~" + o._2 + "~~~" + o._3).mkString("###"))
           if (oadap != null) {
             oadap.send(output._2.map(out => out._3.getBytes("UTF8")).toArray, output._2.map(out => out._2.getBytes("UTF8")).toArray)
           }

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaMdCfg.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaMdCfg.scala
@@ -429,10 +429,6 @@ object KamanjaMdCfg {
 
   private def LoadOutputAdapsForCfg(adaps: scala.collection.mutable.Map[String, AdapterInfo], outputAdapters: ArrayBuffer[OutputAdapter], hasInputAdapterName: Boolean): Boolean = {
     // ConfigurationName
-    if (adaps.size > 1) {
-      LOG.error(" Got %d ouput adapters, but we are expecting only one output adapter.".format(adaps.size))
-      return false
-    }
     adaps.foreach(ac => {
       //BUGBUG:: Not yet validating required fields 
       val conf = new AdapterConfiguration

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/LearningEngine.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/LearningEngine.scala
@@ -157,7 +157,7 @@ class LearningEngine(val input: InputAdapter, val curPartitionKey: PartitionUniq
             LOG.info(" outputMsgs.size" + outputMsgs.get.size)
             var outputGen = new OutputMsgGenerator()
             val resultedoutput = outputGen.generateOutputMsg(msg, resMap, outputMsgs.get.toArray)
-            returnOutput ++= resultedoutput.map(resout => (resout._3, resout._2.mkString(","), resout._3))
+            returnOutput ++= resultedoutput.map(resout => (resout._1, resout._2.mkString(","), resout._3))
           } else {
             val json = ("ModelsResult" -> results.toList.map(res => res.toJson))
             returnOutput ++= allOutputQueueNames.map(adapNm => (adapNm, cntr.toString, compact(render(json)))) // Sending the same result to all queues

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/LearningEngine.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/LearningEngine.scala
@@ -35,6 +35,7 @@ import com.ligadata.Exceptions.StackTrace
 
 class LearningEngine(val input: InputAdapter, val curPartitionKey: PartitionUniqueRecordKey) {
   val LOG = Logger.getLogger(getClass);
+  var cntr: Long = 0
 
   private def RunAllModels(transId: Long, inputData: Array[Byte], finalTopMsgOrContainer: MessageContainerBase, envContext: EnvContext, uk: String, uv: String, xformedMsgCntr: Int, totalXformedMsgs: Int): Array[SavedMdlResult] = {
     var results: ArrayBuffer[SavedMdlResult] = new ArrayBuffer[SavedMdlResult]()
@@ -88,10 +89,11 @@ class LearningEngine(val input: InputAdapter, val curPartitionKey: PartitionUniq
     (topMsgInfo.parents(0)._1, true, topMsgInfo)
   }
 
-  def execute(transId: Long, inputData: Array[Byte], msgType: String, msgInfo: MsgContainerObjAndTransformInfo, inputdata: InputData, envContext: EnvContext, readTmNs: Long, rdTmMs: Long, uk: String, uv: String, xformedMsgCntr: Int, totalXformedMsgs: Int, ignoreOutput: Boolean): Array[(String, String)] = {
+  // Returns Adapter/Queue Name, Partition Key & Output String
+  def execute(transId: Long, inputData: Array[Byte], msgType: String, msgInfo: MsgContainerObjAndTransformInfo, inputdata: InputData, envContext: EnvContext, readTmNs: Long, rdTmMs: Long, uk: String, uv: String, xformedMsgCntr: Int, totalXformedMsgs: Int, ignoreOutput: Boolean, allOutputQueueNames: Array[String]): Array[(String, String, String)] = {
     // LOG.debug("LE => " + msgData)
     LOG.debug("Processing uniqueKey:%s, uniqueVal:%s".format(uk, uv))
-    val returnOutput = ArrayBuffer[(String, String)]() // Adapter/Queue name & output message 
+    val returnOutput = ArrayBuffer[(String, String, String)]() // Adapter/Queue name, PartitionKey & output message 
 
     try {
       if (msgInfo != null && inputdata != null) {
@@ -149,19 +151,18 @@ class LearningEngine(val input: InputAdapter, val curPartitionKey: PartitionUniq
             resMap(res.mdlName) = res.mdlRes.asKeyValuesMap.map(r => { (r._1, r._2) }).toArray
           })
 
-          var resStr = "Not found any output."
           val outputMsgs = KamanjaMetadata.getMdMgr.OutputMessages(true, true)
           if (outputMsgs != None && outputMsgs != null && outputMsgs.get.size > 0) {
             LOG.info("msg " + msg.FullName)
             LOG.info(" outputMsgs.size" + outputMsgs.get.size)
             var outputGen = new OutputMsgGenerator()
             val resultedoutput = outputGen.generateOutputMsg(msg, resMap, outputMsgs.get.toArray)
-            resStr = resultedoutput.map(resout => resout._3).mkString("\n")
+            returnOutput ++= resultedoutput.map(resout => (resout._3, resout._2.mkString(","), resout._3))
           } else {
             val json = ("ModelsResult" -> results.toList.map(res => res.toJson))
-            resStr = compact(render(json))
+            returnOutput ++= allOutputQueueNames.map(adapNm => (adapNm, cntr.toString, compact(render(json)))) // Sending the same result to all queues
+            cntr += 1
           }
-          returnOutput += (("", resStr))
 
           if (isValidPartitionKey) {
             envContext.saveModelsResult(transId, partKeyDataList, allMdlsResults)
@@ -177,6 +178,6 @@ class LearningEngine(val input: InputAdapter, val curPartitionKey: PartitionUniq
         LOG.error("Failed to create and run message. Reason:%s Message:%s\nStackTrace:%s".format(e.getCause, e.getMessage, stackTrace))
       }
     }
-    return Array[(String, String)]()
+    return Array[(String, String, String)]()
   }
 }

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/outputmsg/OutputMsgGenerator.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/outputmsg/OutputMsgGenerator.scala
@@ -53,7 +53,7 @@ class OutputMsgGenerator {
     } catch {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.debug("\nStackTrace:"+stackTrace)
+        log.error("\nStackTrace:"+stackTrace)
         throw new Exception(e.getMessage())
       }
     }
@@ -82,7 +82,7 @@ class OutputMsgGenerator {
           })
           val pkey = partitionKey._1 + key
           val parttionkey = myMap.getOrElse(pkey, "")
-          paritionKeys +:= parttionkey.toString
+          paritionKeys +:= ValueToString(parttionkey, ",")
         })
 
         val queueName = outputMsgDef.Queue
@@ -92,7 +92,7 @@ class OutputMsgGenerator {
     } catch {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.debug("\nStackTrace:"+stackTrace)
+        log.error("\nStackTrace:"+stackTrace)
         throw new Exception(e.getMessage())
       }
     }
@@ -102,9 +102,9 @@ class OutputMsgGenerator {
   private def GetValue(m: scala.util.matching.Regex.Match) = {
     import java.util.regex.Matcher
     val grp = m.group(1)
-    // Get the value from Declaration Variable or Message or Models for varname. Tulasi populate varvalue
+    // Get the value from Declaration Variable or Message or Models for varname.
     val varvalue = myMap.getOrElse(grp.toString().toLowerCase(), null)
-    varvalue.toString
+    ValueToString(varvalue, ",")
   }
   /**
    *
@@ -175,7 +175,7 @@ class OutputMsgGenerator {
     } catch {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.debug("\nStackTrace:"+stackTrace)
+        log.error("\nStackTrace:"+stackTrace)
         throw new Exception(e.getMessage())
       }
     }
@@ -289,7 +289,7 @@ class OutputMsgGenerator {
         } else if (message.isInstanceOf[MessageContainerBase]) {
           val value = message.asInstanceOf[MessageContainerBase].get(fldName.toString)
           if (typetype.equals("tstring") || typetype.equals("tlong") || typetype.equals("tfloat") || typetype.equals("tdouble") || typetype.equals("tboolean") || typetype.equals("tchar") || typetype.equals("tint")) {
-            return value.toString
+            return ValueToString(value, ",")
           } else {
             return getMsgFldValue(value, fld(index + 1)._1, fld(index + 1)._2, fld, index + 1, delimiter)
           }
@@ -299,7 +299,7 @@ class OutputMsgGenerator {
     } catch {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.debug("\nStackTrace:"+stackTrace)
+        log.error("\nStackTrace:"+stackTrace)
         throw new Exception(e.getMessage())
       }
     }
@@ -307,6 +307,7 @@ class OutputMsgGenerator {
   }
 
   private def ValueToString(v: Any, delimiter: String): String = {
+    if (v == null) return ""
     if (v.isInstanceOf[Set[_]]) {
       return v.asInstanceOf[Set[_]].mkString(delimiter)
     }

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/outputmsg/OutputMsgGenerator.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/outputmsg/OutputMsgGenerator.scala
@@ -54,7 +54,7 @@ class OutputMsgGenerator {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
         log.error("\nStackTrace:"+stackTrace)
-        throw new Exception(e.getMessage())
+        throw e
       }
     }
   }
@@ -93,7 +93,7 @@ class OutputMsgGenerator {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
         log.error("\nStackTrace:"+stackTrace)
-        throw new Exception(e.getMessage())
+        throw e
       }
     }
     output.toArray
@@ -176,7 +176,7 @@ class OutputMsgGenerator {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
         log.error("\nStackTrace:"+stackTrace)
-        throw new Exception(e.getMessage())
+        throw e
       }
     }
   }
@@ -300,7 +300,7 @@ class OutputMsgGenerator {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
         log.error("\nStackTrace:"+stackTrace)
-        throw new Exception(e.getMessage())
+        throw e
       }
     }
     return null

--- a/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
+++ b/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
@@ -394,14 +394,16 @@ object OutputMsgDefImpl {
 
     try {
       if (container != null) {
-        if (container.containerType.isInstanceOf[StructTypeDef]) {
+        val isFixed = container.containerType.asInstanceOf[ContainerTypeDef].IsFixed
+
+        if (isFixed) {
           val memberDefs = container.containerType.asInstanceOf[StructTypeDef].memberDefs
           if (memberDefs != null) {
             log.info("==== fixedcontainer")
             childs ++= memberDefs.filter(a => (a.isInstanceOf[AttributeDef])).map(a => (a.Name, a))
           }
           typeOf = "fixedcontainer"
-        } else if (container.containerType.isInstanceOf[MappedMsgTypeDef]) { // Mapped
+        } else { // Mapped
           val attrMap = container.containerType.asInstanceOf[MappedMsgTypeDef].attrMap
           if (attrMap != null) {
             childs ++= attrMap.filter(a => (a._2.isInstanceOf[AttributeDef])).map(a => (a._2.Name, a._2))
@@ -410,14 +412,16 @@ object OutputMsgDefImpl {
           log.info(typeOf)
         }
       } else if (message != null) {
-        if (message.containerType.isInstanceOf[StructTypeDef]) {
+        val isFixed = message.containerType.asInstanceOf[ContainerTypeDef].IsFixed
+
+        if (isFixed) {
           val memberDefs = message.containerType.asInstanceOf[StructTypeDef].memberDefs
           if (memberDefs != null) {
             childs ++= memberDefs.filter(a => (a.isInstanceOf[AttributeDef])).map(a => (a.Name, a))
           }
           typeOf = "fixedmessage"
           log.info(typeOf)
-        } else if (message.containerType.isInstanceOf[MappedMsgTypeDef]) {
+        } else {
           val attrMap = message.containerType.asInstanceOf[MappedMsgTypeDef].attrMap
           if (attrMap != null) {
             childs ++= attrMap.filter(a => (a._2.isInstanceOf[AttributeDef])).map(a => (a._2.Name, a._2))

--- a/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
+++ b/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
@@ -68,7 +68,7 @@ object OutputMsgDefImpl {
       val outputQ = outputMessageDef.Queue.toLowerCase()
       val paritionKeys = outputMessageDef.PartitionKey
       val dataDeclaration = outputMessageDef.DataDeclaration
-      val outputFormat = outputMessageDef.OutputFormat.toLowerCase()
+      val outputFormat = outputMessageDef.OutputFormat
       val defaults = outputMessageDef.Defaults
       val name = outputMessageDef.Name.toLowerCase()
       val nameSpace = outputMessageDef.NameSpace.toLowerCase()
@@ -177,7 +177,7 @@ object OutputMsgDefImpl {
   private def extractOutputFormat(outputformat: String): Array[String] = {
     val extractor = """\$\{([^}]+)\}""".r
     val finds = extractor.findAllIn(outputformat)
-    val allOutputFnds = finds.toArray
+    val allOutputFnds = finds.map(fld => fld.toLowerCase()).toArray
     allOutputFnds
   }
 

--- a/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
+++ b/trunk/OutputMsgDef/src/main/scala/com/ligadata/outputmsgdef/OutputMsgDefImpl.scala
@@ -62,8 +62,8 @@ object OutputMsgDefImpl {
       log.debug("Version " + outputMessageDef.Version)
       log.debug("Queue" + outputMessageDef.Queue)
       log.debug("OutputFormat " + outputMessageDef.OutputFormat)
-      outputMessageDef.DataDeclaration.foreach(f =>  log.debug("f " + f))
-      outputMessageDef.Defaults.foreach(f =>  log.debug("f " + f))
+      outputMessageDef.DataDeclaration.foreach(f => log.debug("f " + f))
+      outputMessageDef.Defaults.foreach(f => log.debug("f " + f))
 
       val outputQ = outputMessageDef.Queue.toLowerCase()
       val paritionKeys = outputMessageDef.PartitionKey
@@ -109,6 +109,7 @@ object OutputMsgDefImpl {
       if (paritionKeys != null && paritionKeys.size > 0) {
         paritionKeys.foreach(partionkey => {
           val (fullname, fieldsInfo, typeOf, fullpartionkey) = getFieldsInfo(partionkey)
+          log.debug("fullname:%s, fieldsInfo:%s, typeOf:%s, fullpartionkey:%s".format(fullname, fieldsInfo.mkString("~~"), typeOf, fullpartionkey))
           partionFieldKeys = partionFieldKeys :+ (fullname, fieldsInfo.toArray, typeOf, fullpartionkey)
           var defaultValue: String = null
           if (dfaults.contains(partionkey)) {
@@ -117,11 +118,13 @@ object OutputMsgDefImpl {
           var fldInfo: Array[(String, String)] = fieldsInfo.asInstanceOf[Array[(String, String)]]
           var value: Array[(String, String)] = Array[(String, String)]()
           value = fldInfo
-          if (Fields.contains((fullname, typeOf)))
+          if (Fields.contains((fullname, typeOf))) {
+            log.debug("1-fullname:%s, typeOf:%s".format(fullname, typeOf))
             Fields((fullname, typeOf)) += ((value, defaultValue))
-          else {
+          } else {
             var valueVal: scala.collection.mutable.Set[(Array[(String, String)], String)] = scala.collection.mutable.Set[(Array[(String, String)], String)]()
             valueVal += ((fldInfo, defaultValue))
+            log.debug("2-fullname:%s, typeOf:%s".format(fullname, typeOf))
             Fields((fullname, typeOf)) = (valueVal)
           }
 
@@ -148,11 +151,13 @@ object OutputMsgDefImpl {
           var fldInfo: Array[(String, String)] = fieldsInfo.asInstanceOf[Array[(String, String)]]
           var value: Array[(String, String)] = Array[(String, String)]()
           value = fldInfo
-          if (Fields.contains((fullname, typeOf)))
+          if (Fields.contains((fullname, typeOf))) {
+            log.debug("3-fullname:%s, typeOf:%s".format(fullname, typeOf))
             Fields((fullname, typeOf)) += ((value, defaultValue))
-          else {
+          } else {
             var valueVal: scala.collection.mutable.Set[(Array[(String, String)], String)] = scala.collection.mutable.Set[(Array[(String, String)], String)]()
             valueVal += ((fldInfo, defaultValue))
+            log.debug("4-fullname:%s, typeOf:%s".format(fullname, typeOf))
             Fields((fullname, typeOf)) = (valueVal)
           }
         })
@@ -167,7 +172,7 @@ object OutputMsgDefImpl {
       }
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.trace("Error " + e.getMessage()+"\nStackTrace:"+stackTrace)
+        log.trace("Error " + e.getMessage() + "\nStackTrace:" + stackTrace)
         throw e
       }
     }
@@ -196,38 +201,66 @@ object OutputMsgDefImpl {
       val partionKeyParts = fullpartionkey.split("\\.")
       if (partionKeyParts.size < 3)
         throw new Exception("Please provide the fiels in format of Namespace.Name.fieldname")
-      
-      val(namespace, name, field) = com.ligadata.kamanja.metadata.Utils.parseNameToken(fullpartionkey)
-      val (containerDef, messageDef, modelDef) = getModelMsgContainer(namespace, name)
+
+      var namespaceWords = 1
+      var foundFullName = false
+
+      var containerDef: ContainerDef = null
+      var messageDef: MessageDef = null
+      var modelDef: ModelDef = null
+
+      while (foundFullName == false && (namespaceWords + 1) < partionKeyParts.size) {
+        val tmpNamespace = partionKeyParts.take(namespaceWords).mkString(".")
+        val tmpName = partionKeyParts(namespaceWords)
+        val (tmpContainerDef, tmpMessageDef, tmpModelDef) = getModelMsgContainer(tmpNamespace, tmpName)
+        if (tmpContainerDef != null || tmpMessageDef != null || tmpModelDef != null) {
+          containerDef = tmpContainerDef
+          messageDef = tmpMessageDef
+          modelDef = tmpModelDef
+          foundFullName = true
+        } else {
+          namespaceWords += 1
+        }
+      }
+
+      if (containerDef == null && messageDef == null && modelDef == null) {
+        throw new ObjectNolongerExistsException(s"Either Model or Message or Container do not exists in Metadata for $fullpartionkey given in output Message definition.")
+      }
+
+      val namespace = partionKeyParts.take(namespaceWords).mkString(".")
+      val name = partionKeyParts(namespaceWords)
+
       val (childs, typeOf) = getModelMsgContainerChilds(containerDef, messageDef, modelDef)
       typeof = typeOf
-      for (i <- 2 until partionKeyParts.size) {
-        val fld = partionKeyParts(i).toString().toLowerCase()
+      log.debug("namespace:%s, name:%s, typeof:%s, namespaceWords:%d".format(namespace, name, typeof, namespaceWords))
 
-        if (i == 2) {
+      for (i <- (namespaceWords + 1) until partionKeyParts.size) {
+        if (i == (namespaceWords + 1)) {
+          val fld = partionKeyParts(i).toString().toLowerCase()
           val fldType = getFieldTypeFromMsgCtr(childs, fld)
           fieldsInfo += ((fld, fldType))
 
-        } else if (i > 2) {
+        } else if (i > (namespaceWords + 1)) {
           fieldsInfo.foreach(f => log.info("====fieldInfos========" + f._1 + "======" + f._2))
-          val parent = fieldsInfo(i - 3)
+          val parent = fieldsInfo(i - (namespaceWords + 1 + 1))
           val parentType = parent._2.toLowerCase()
           val fieldName = partionKeyParts(i).toString().toLowerCase()
           val fieldType = getFieldType(fieldName, parentType)
           fieldsInfo += ((fieldName, fieldType))
         }
-
       }
       fullname = namespace + "." + name
+      log.debug("fullname:%s".format(fullname))
 
     } catch {
       case e: ObjectNolongerExistsException => {
-        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: "+ e.getMessage)
+        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: " + e.getMessage)
         throw e
       }
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.trace("Error " + e.getMessage()+"\nStackTrace:"+stackTrace)
+        log.error("Error " + e.getMessage() + "\nStackTrace:" + stackTrace)
+        throw e
       }
     }
     (fullname, fieldsInfo.toArray, typeof, fullpartionkey.toLowerCase())
@@ -248,12 +281,12 @@ object OutputMsgDefImpl {
       })
     } catch {
       case e: ObjectNolongerExistsException => {
-        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: "+ e.getMessage)
+        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: " + e.getMessage)
         throw e
       }
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.trace("Error " + e.getMessage()+"\nStackTrace:"+stackTrace)
+        log.trace("Error " + e.getMessage() + "\nStackTrace:" + stackTrace)
       }
     }
     fldtype.toLowerCase()
@@ -297,7 +330,7 @@ object OutputMsgDefImpl {
       }
     } catch {
       case e: ObjectNolongerExistsException => {
-        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: "+ e.getMessage)
+        log.error(s"Either Model or Message or Container do not exists in Metadata. Error: " + e.getMessage)
         throw e
       }
       case e: Exception => {
@@ -314,7 +347,7 @@ object OutputMsgDefImpl {
     var modelObj: ModelDef = null
     var prevVerMsgObjstr: String = ""
     var childs: ArrayBuffer[(String, String)] = ArrayBuffer[(String, String)]()
-    
+
     if (namespace == null || namespace.trim() == "")
       throw new Exception("Proper Namespace do not exists in message/container definition")
     if (name == null || name.trim() == "")
@@ -348,10 +381,6 @@ object OutputMsgDefImpl {
         modelObj = m.asInstanceOf[ModelDef]
     }
 
-    if (msgdefObj == null && cntainerObj == null && modelObj == null) {
-      throw new ObjectNolongerExistsException(s"Either Model or Message or Container do not exists in Metadata for $namespace.$name given in output Message definition.")
-    }
-
     (cntainerObj, msgdefObj, modelObj)
 
   }
@@ -365,16 +394,14 @@ object OutputMsgDefImpl {
 
     try {
       if (container != null) {
-        val fixed = container.containerType.asInstanceOf[StructTypeDef].IsFixed
-
-        if (fixed) {
+        if (container.containerType.isInstanceOf[StructTypeDef]) {
           val memberDefs = container.containerType.asInstanceOf[StructTypeDef].memberDefs
           if (memberDefs != null) {
             log.info("==== fixedcontainer")
             childs ++= memberDefs.filter(a => (a.isInstanceOf[AttributeDef])).map(a => (a.Name, a))
           }
           typeOf = "fixedcontainer"
-        } else if (!fixed) {
+        } else if (container.containerType.isInstanceOf[MappedMsgTypeDef]) { // Mapped
           val attrMap = container.containerType.asInstanceOf[MappedMsgTypeDef].attrMap
           if (attrMap != null) {
             childs ++= attrMap.filter(a => (a._2.isInstanceOf[AttributeDef])).map(a => (a._2.Name, a._2))
@@ -383,16 +410,14 @@ object OutputMsgDefImpl {
           log.info(typeOf)
         }
       } else if (message != null) {
-        val fixed = message.containerType.asInstanceOf[StructTypeDef].IsFixed
-
-        if (fixed) {
+        if (message.containerType.isInstanceOf[StructTypeDef]) {
           val memberDefs = message.containerType.asInstanceOf[StructTypeDef].memberDefs
           if (memberDefs != null) {
             childs ++= memberDefs.filter(a => (a.isInstanceOf[AttributeDef])).map(a => (a.Name, a))
           }
           typeOf = "fixedmessage"
           log.info(typeOf)
-        } else if (!fixed) {
+        } else if (message.containerType.isInstanceOf[MappedMsgTypeDef]) {
           val attrMap = message.containerType.asInstanceOf[MappedMsgTypeDef].attrMap
           if (attrMap != null) {
             childs ++= attrMap.filter(a => (a._2.isInstanceOf[AttributeDef])).map(a => (a._2.Name, a._2))
@@ -409,7 +434,7 @@ object OutputMsgDefImpl {
     } catch {
       case e: Exception => {
         val stackTrace = StackTrace.ThrowableTraceString(e)
-        log.debug("Error " + e.getMessage()+"\nStackTrace:"+stackTrace)
+        log.debug("Error " + e.getMessage() + "\nStackTrace:" + stackTrace)
         throw e
       }
     }


### PR DESCRIPTION
1. Allowing multiple output adapters
2. If we specify any Output Message definitions, we are just sending output to the corresponding output adapter which are specified in Output message. If we don't have any output message definitions, we send the default output to all output adapters.
3. This may break exactly once. Not yet extensively tested that.
4. This branch is created on top of OutputMsgDefFixes branch.
