### PR TITLE
When creating a new MetadataAPIProperties, I am passing in the zookee…

### DIFF
--- a/trunk/MetadataAPI/src/test/scala/LocalTestFixtures.scala
+++ b/trunk/MetadataAPI/src/test/scala/LocalTestFixtures.scala
@@ -28,6 +28,6 @@ trait CommonResources {
 }
 
 trait LocalTestFixtures extends CommonResources {
-  val mdMan: MetadataManager = new MetadataManager(new MetadataAPIProperties)
   val zkServer = EmbeddedZookeeper
+  val mdMan: MetadataManager = new MetadataManager(new MetadataAPIProperties(zkConnStr = zkServer.instance.getConnection))
 }


### PR DESCRIPTION
…per connection info from EmbeddedZookeeper.