### PR TITLE
We are loading dependency jars while getting Model Information (model name, version, etc).

### DIFF
--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/CompilerProxy.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/CompilerProxy.scala
@@ -499,8 +499,10 @@ class CompilerProxy {
         throw new ModelCompilationFailedException("Failed to produce the jar file")
       }
 
+      val depJars = getJarsFromClassPath(classPath)
+      
       // figure out the Physical Model Name
-      var (dummy1, dummy2, dummy3, pName) = getModelMetadataFromJar(jarFileName, elements)
+      var (dummy1, dummy2, dummy3, pName) = getModelMetadataFromJar(jarFileName, elements, depJars)
 
       // Create the ModelDef object
       val modDef: ModelDef = MdMgr.GetMdMgr.MakeModelDef(modelNamespace, modelName, "", "RuleSet",
@@ -518,11 +520,13 @@ class CompilerProxy {
       modDef
     } catch {
       case e: AlreadyExistsException => {
-        logger.error("Failed to compile the model definition " + e.toString)
+        val stackTrace = StackTrace.ThrowableTraceString(e)
+        logger.error("Failed to compile the model definition:%s.\nStackTrace:%s".format(e.toString, stackTrace))
         throw e
       }
       case e: Exception => {
-        logger.error("Failed to compile the model definition " + e.toString)
+        val stackTrace = StackTrace.ThrowableTraceString(e)
+        logger.error("Failed to compile the model definition:%s.\nStackTrace:%s".format(e.toString, stackTrace))
         throw new ModelCompilationFailedException(e.getMessage())
       }
     }
@@ -631,12 +635,14 @@ class CompilerProxy {
       logger.error("COMPILER_PROXY: Error compiling model source. Unable to create Jar RC = " + status)
       throw new MsgCompilationFailedException(modelConfigName)
     }
+    
+    val depJars = getJarsFromClassPath(classPath)
 
-    (getModelMetadataFromJar(jarFileName, elements), finalSourceCode, packageName)
+    (getModelMetadataFromJar(jarFileName, elements, depJars), finalSourceCode, packageName)
 
   }
 
-  private def getModelMetadataFromJar(jarFileName: String, elements: Set[BaseElemDef]): (String, String, String, String) = {
+  private def getModelMetadataFromJar(jarFileName: String, elements: Set[BaseElemDef], depJars: List[String]): (String, String, String, String) = {
 
     // Resolve ModelNames and Models versions - note, the jar file generated is still in the workDirectory.
     val loaderInfo = new KamanjaLoaderInfo()
@@ -655,6 +661,9 @@ class CompilerProxy {
         allJars = allJars ++ elem.DependencyJarNames
       }
     })
+
+    if (depJars != null)
+      allJars = allJars ++ depJars
 
     Utils.LoadJars(allJars.map(j => Utils.GetValidJarFile(jarPaths0, j)).toArray, loaderInfo.loadedJars, loaderInfo.loader)
 
@@ -773,6 +782,26 @@ class CompilerProxy {
     None
   }
 
+  private def getJarsFromClassPath(clsPath: String): List[String] = {
+    // Pull all the jar files in the classpath into a set...  THIS WILL CHANGE IN A FUTURE since we
+    // dont want to allow developers using the classpath to pass in dependencies.
+    var returnList = ArrayBuffer[String]()
+    var depArray: Array[String] = clsPath.trim.split(":")
+    depArray.foreach(dep => {
+      // Check it is the file & the file exists
+      val fl = new File(dep.trim)
+      if (fl.exists && fl.isFile /* && fl.canRead() */) {
+          returnList += fl.getName
+      } else {
+        var parsedJarpath = dep.split("/")
+        var tempSanity = parsedJarpath(parsedJarpath.length - 1).split('.')
+        if (tempSanity(tempSanity.length - 1).trim.equalsIgnoreCase("jar"))
+          returnList += (tempSanity.mkString(".").trim)
+      }
+    })
+    returnList.toList
+  }
+  
   /**
    * addDepsFromClassPath - this is probably a temporary metho here for now.  THIS WILL CHANGE IN A FUTURE since we
    * dont want to allow developers using the classpath to pass in dependencies.
@@ -780,15 +809,7 @@ class CompilerProxy {
   private def addDepsFromClassPath(): List[String] = {
     // Pull all the jar files in the classpath into a set...  THIS WILL CHANGE IN A FUTURE since we
     // dont want to allow developers using the classpath to pass in dependencies.
-    var returnList: List[String] = List[String]()
-    var depArray: Array[String] = MetadataAPIImpl.GetMetadataAPIConfig.getProperty("CLASSPATH").trim.split(":")
-    depArray.foreach(dep => {
-      var parsedJarpath = dep.split("/")
-      var tempSanity = parsedJarpath(parsedJarpath.length - 1).split('.')
-      if (tempSanity(tempSanity.length - 1).trim.equalsIgnoreCase("jar"))
-        returnList = returnList ::: List[String](tempSanity.mkString(".").trim)
-    })
-    returnList
+    getJarsFromClassPath(MetadataAPIImpl.GetMetadataAPIConfig.getProperty("CLASSPATH"))
   }
 
   /**


### PR DESCRIPTION
William,

This is related to Java/Scala models.

1. Have a model which is referring some class from external jar.
2. Include that jar name either in classpath of Properties file or compile configs.(Assuming you already have it in jarpaths folder, ex: lib/system or lib/application)
3. Try to add the model. It should fails without this branch. It compiles the jar, but while getting the model information (name, version,etc) it fails.

This fix is just to load the dependencies also while loading the compiled jar.

This may need to go as HOT FIX on 1.1.X. I think Heman is waiting for it to deploy in customer place.