### PR TITLE
Added space between log4j dependencies in build.sbt

### DIFF
--- a/trunk/AuditAdapters/AuditAdapterBase/build.sbt
+++ b/trunk/AuditAdapters/AuditAdapterBase/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 

--- a/trunk/DataDelimiters/build.sbt
+++ b/trunk/DataDelimiters/build.sbt
@@ -5,5 +5,6 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/EnvContexts/SimpleEnvContextImpl/build.sbt
+++ b/trunk/EnvContexts/SimpleEnvContextImpl/build.sbt
@@ -7,5 +7,6 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/Exceptions/build.sbt
+++ b/trunk/Exceptions/build.sbt
@@ -5,5 +5,6 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/FactoriesOfModelInstanceFactory/JarFactoryOfModelInstanceFactory/build.sbt
+++ b/trunk/FactoriesOfModelInstanceFactory/JarFactoryOfModelInstanceFactory/build.sbt
@@ -7,5 +7,6 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/HeartBeat/build.sbt
+++ b/trunk/HeartBeat/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-actors" % _)

--- a/trunk/InputOutputAdapters/FileSimpleInputOutputAdapters/build.sbt
+++ b/trunk/InputOutputAdapters/FileSimpleInputOutputAdapters/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-actors" % _)

--- a/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/build.sbt
+++ b/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 resolvers += "Apache repo" at "https://repository.apache.org/content/repositories/releases"

--- a/trunk/InputOutputAdapters/InputOutputAdapterBase/build.sbt
+++ b/trunk/InputOutputAdapters/InputOutputAdapterBase/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 

--- a/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/build.sbt
+++ b/trunk/InputOutputAdapters/KafkaSimpleInputOutputAdapters/build.sbt
@@ -8,6 +8,7 @@ resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Apache repo" at "https://repository.apache.org/content/repositories/releases"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies ++= Seq("org.apache.kafka" % "kafka_2.10" % "0.8.1.1"

--- a/trunk/KamanjaBase/build.sbt
+++ b/trunk/KamanjaBase/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/KamanjaManager/build.sbt
+++ b/trunk/KamanjaManager/build.sbt
@@ -61,6 +61,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-actors" % _)

--- a/trunk/KamanjaUtils/build.sbt
+++ b/trunk/KamanjaUtils/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/MessageDef/build.sbt
+++ b/trunk/MessageDef/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "metadata" % "metadata_2.10" % "1.0"

--- a/trunk/Metadata/build.sbt
+++ b/trunk/Metadata/build.sbt
@@ -9,6 +9,7 @@ libraryDependencies += "org.joda" % "joda-convert" % "1.6"
 libraryDependencies += "joda-time" % "joda-time" % "2.8.2"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/MetadataAPI/build.sbt
+++ b/trunk/MetadataAPI/build.sbt
@@ -66,6 +66,7 @@ libraryDependencies += "joda-time" % "joda-time" % "2.8.2"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/MetadataAPIServiceClient/build.sbt
+++ b/trunk/MetadataAPIServiceClient/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
 )
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/OutputMsgDef/build.sbt
+++ b/trunk/OutputMsgDef/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "metadata" % "metadata_2.10" % "1.0"

--- a/trunk/SampleApplication/InterfacesSamples/build.sbt
+++ b/trunk/SampleApplication/InterfacesSamples/build.sbt
@@ -5,6 +5,7 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/SecurityAdapters/SecurityAdapterBase/build.sbt
+++ b/trunk/SecurityAdapters/SecurityAdapterBase/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 

--- a/trunk/Storage/Cassandra/build.sbt
+++ b/trunk/Storage/Cassandra/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "commons-dbcp" % "commons-dbcp" % "1.4"

--- a/trunk/Storage/HBase/build.sbt
+++ b/trunk/Storage/HBase/build.sbt
@@ -19,4 +19,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Storage/HashMap/build.sbt
+++ b/trunk/Storage/HashMap/build.sbt
@@ -15,4 +15,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Storage/MySql/build.sbt
+++ b/trunk/Storage/MySql/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "commons-dbcp" % "commons-dbcp" % "1.4"

--- a/trunk/Storage/Redis/build.sbt
+++ b/trunk/Storage/Redis/build.sbt
@@ -15,4 +15,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Storage/SqlServer/build.sbt
+++ b/trunk/Storage/SqlServer/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.apache.commons" % "commons-dbcp2" % "2.1"

--- a/trunk/Storage/StorageBase/build.sbt
+++ b/trunk/Storage/StorageBase/build.sbt
@@ -5,5 +5,6 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/Storage/StorageManager/build.sbt
+++ b/trunk/Storage/StorageManager/build.sbt
@@ -13,4 +13,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Storage/TreeMap/build.sbt
+++ b/trunk/Storage/TreeMap/build.sbt
@@ -15,4 +15,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Storage/Voldemort/build.sbt
+++ b/trunk/Storage/Voldemort/build.sbt
@@ -17,5 +17,6 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 

--- a/trunk/TransactionService/build.sbt
+++ b/trunk/TransactionService/build.sbt
@@ -13,4 +13,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.9" 
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Utils/Audit/build.sbt
+++ b/trunk/Utils/Audit/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies += "com.google.protobuf" % "protobuf-java" % "2.3.0"
 libraryDependencies += "voldemort" % "voldemort" % "0.96"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "commons-codec" % "commons-codec" % "1.9"

--- a/trunk/Utils/Controller/build.sbt
+++ b/trunk/Utils/Controller/build.sbt
@@ -61,6 +61,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/Utils/ExtractData/build.sbt
+++ b/trunk/Utils/ExtractData/build.sbt
@@ -61,6 +61,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/Utils/JdbcDataCollector/build.sbt
+++ b/trunk/Utils/JdbcDataCollector/build.sbt
@@ -61,6 +61,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/Utils/JsonDataGen/build.sbt
+++ b/trunk/Utils/JsonDataGen/build.sbt
@@ -60,6 +60,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"

--- a/trunk/Utils/KVInit/build.sbt
+++ b/trunk/Utils/KVInit/build.sbt
@@ -61,4 +61,5 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Utils/SaveContainerDataComponent/build.sbt
+++ b/trunk/Utils/SaveContainerDataComponent/build.sbt
@@ -59,6 +59,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/Utils/Security/SimpleApacheShiroAdapter/build.sbt
+++ b/trunk/Utils/Security/SimpleApacheShiroAdapter/build.sbt
@@ -64,6 +64,7 @@ libraryDependencies += "joda-time" % "joda-time" % "2.8.2"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/Utils/Serialize/build.sbt
+++ b/trunk/Utils/Serialize/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9" 

--- a/trunk/Utils/SimpleKafkaProducer/build.sbt
+++ b/trunk/Utils/SimpleKafkaProducer/build.sbt
@@ -44,6 +44,7 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 resolvers += "Apache repo" at "https://repository.apache.org/content/repositories/releases"

--- a/trunk/Utils/UtilsForModels/build.sbt
+++ b/trunk/Utils/UtilsForModels/build.sbt
@@ -57,4 +57,5 @@ scalaVersion := "2.10.4"
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"

--- a/trunk/Utils/ZooKeeper/CuratorClient/build.sbt
+++ b/trunk/Utils/ZooKeeper/CuratorClient/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 // libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.5"

--- a/trunk/Utils/ZooKeeper/CuratorLeaderLatch/build.sbt
+++ b/trunk/Utils/ZooKeeper/CuratorLeaderLatch/build.sbt
@@ -61,6 +61,7 @@ scalaVersion := "2.10.4"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 // libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.5"

--- a/trunk/Utils/ZooKeeper/CuratorListener/build.sbt
+++ b/trunk/Utils/ZooKeeper/CuratorListener/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.4"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.0"
 
 libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
+
 libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
 
 // libraryDependencies += "org.slf4j" % "slf4j-log4j12" % "1.7.5"


### PR DESCRIPTION
i.e. between these two dependencies
libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.4.1"
libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.4.1"