### PR TITLE
jvm options for Kamanja MetadataAPI, Manager/Engine and Web service

### DIFF
--- a/trunk/SampleApplication/EasyInstall/template/config/MetadataAPIConfig_Template.properties
+++ b/trunk/SampleApplication/EasyInstall/template/config/MetadataAPIConfig_Template.properties
@@ -30,3 +30,4 @@ AUDIT_IMPL_CLASS=com.ligadata.audit.adapters.AuditCassandraAdapter
 DO_AUDIT=NO
 DO_AUTH=NO
 SSL_CERTIFICATE={InstallDirectory}/config/keystore.jks
+JVM=-Xms128m -Xmx2g

--- a/trunk/SampleApplication/EasyInstall/template/script/StartEngine_Template.sh
+++ b/trunk/SampleApplication/EasyInstall/template/script/StartEngine_Template.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
+JVMOPTIONS=$@
 KAMANJA_HOME={InstallDirectory}
 
 # Start the engine with hashdb backed metadata configuration.  The zookeeper and your queue software should be running
 ipport="8998"
 
 if [ "$1" != "debug" ]; then
-	java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/KamanjaManager-1.0 --config $KAMANJA_HOME/config/Engine1Config.properties
+	java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/KamanjaManager-1.0 --config $KAMANJA_HOME/config/Engine1Config.properties
 else
-	java -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/KamanjaManager-1.0 --config $KAMANJA_HOME/config/Engine1Config.properties
+	java $JVMOPTIONS -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/KamanjaManager-1.0 --config $KAMANJA_HOME/config/Engine1Config.properties
 fi

--- a/trunk/Utils/Script/kamanja
+++ b/trunk/Utils/Script/kamanja
@@ -70,20 +70,26 @@ if [ "${array[0] }" = "edit" ]; then
   exit 0
 fi
 
+grep -i "jvm" MetadataAPIConfig.properties >> /dev/null
+ISJVM=$?
+if [ $ISJVM = 0 ]; then
+  JVMOPTIONS=`grep -i "jvm" MetadataAPIConfig.properties | cut -d"=" -f2`
+  echo JVM options are $JVMOPTIONS
+fi
+
+
 if [ "$INPUT" = "start webservice" ]; then
 echo "Starting web service . . . ."
-
-java -jar $KAMANJA_HOME/bin/MetadataAPIService-1.0
+java $JVMOPTIONS -jar $KAMANJA_HOME/bin/MetadataAPIService-1.0
 elif [ "$INPUT" = "start -v" ]; then
-   $KAMANJA_HOME/bin/StartEngine.sh
+   $KAMANJA_HOME/bin/StartEngine.sh $JVMOPTIONS
 
 elif [ "$INPUT" = "start" ]; then
   if [ -f /tmp/kamanjastart.log ]; then
     rm /tmp/kamanjastart.log
     touch /tmp/kamanjastart.log
   fi
-
- nohup $KAMANJA_HOME/bin/StartEngine.sh >> $HOME/kamanjastart.log &
+ nohup $KAMANJA_HOME/bin/StartEngine.sh $JVMOPTIONS >> $HOME/kamanjastart.log &
  echo "Kamanja engine started in background. Please check the engine log at /tmp/kamanjastart.log"
 elif [ "$INPUT" = "stop" ]; then
     ID=`ps -ef | grep -i java | grep -i KamanjaManager-1.0 | tr -s " " | cut -d" " -f3`
@@ -127,5 +133,5 @@ elif [ "$INPUT" = "push data" ]; then
 #echo "User selected: $INPUTFILE"
 #$INPUTFILE
 else
-java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/MetadataAPI-1.0 $INPUT
+java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -jar $KAMANJA_HOME/bin/MetadataAPI-1.0 $INPUT
 fi


### PR DESCRIPTION
Hi,

The code is updated such that the kamanja script picks up the JVM options from the Metadata API properties file. These options are then added to `the Kamanja Metadata API, Kamanja Manager/ Engine and the Kamanja Web service.