### PR TITLE
Fixed most of the 2.11 warnings.

### DIFF
--- a/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/build.sbt
+++ b/trunk/InputOutputAdapters/IbmMqSimpleInputOutputAdapters/build.sbt
@@ -21,3 +21,5 @@ libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.9"
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.0" % "test"
 
 libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2" % "test"
+
+EclipseKeys.relativizeLibs := false

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/StartMetadataAPI.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/StartMetadataAPI.scala
@@ -318,7 +318,7 @@ object StartMetadataAPI {
       }
     }
     catch {
-      case e: Exception => response = e.getStackTraceString
+      case e: Exception => response = e.getStackTrace.toString
     }
     response
   }

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/TestMetadataAPI.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/TestMetadataAPI.scala
@@ -91,7 +91,7 @@ object TestMetadataAPI {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == typFiles.length + 1) {
         return
@@ -133,7 +133,7 @@ object TestMetadataAPI {
       typKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > typKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -184,7 +184,7 @@ object TestMetadataAPI {
       typKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > typKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -242,7 +242,7 @@ object TestMetadataAPI {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == fcnFiles.length + 1) {
         return
@@ -290,7 +290,7 @@ object TestMetadataAPI {
       })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > fcnKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -330,7 +330,7 @@ object TestMetadataAPI {
       fcnKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > fcnKeys.length) {
         println("Invalid choice " + choice + ", start with main menu...")
@@ -427,7 +427,7 @@ object TestMetadataAPI {
       msgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > msgKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -470,7 +470,7 @@ object TestMetadataAPI {
       msgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > msgKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -514,7 +514,7 @@ object TestMetadataAPI {
       contKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > contKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -552,7 +552,7 @@ object TestMetadataAPI {
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -592,7 +592,7 @@ object TestMetadataAPI {
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -629,7 +629,7 @@ object TestMetadataAPI {
       msgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > msgKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -667,7 +667,7 @@ object TestMetadataAPI {
       contKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > contKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -711,7 +711,7 @@ println("Getting Messages")
       msgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > msgKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -749,7 +749,7 @@ println("Getting Messages")
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -788,7 +788,7 @@ println("Getting Messages")
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -826,7 +826,7 @@ println("Getting Messages")
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -864,7 +864,7 @@ println("Getting Messages")
       modKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > modKeys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -1006,8 +1006,8 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -1081,8 +1081,8 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -1168,8 +1168,8 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -1240,8 +1240,8 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -1318,7 +1318,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == pmmlFiles.length + 1)
         return
@@ -1407,7 +1407,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == sourceFiles.length + 1) {
         return
@@ -1438,7 +1438,7 @@ println("Getting Messages")
       seq += 1
       println("[" + seq + "] Main Menu")      
       print("\nEnter your choice: ")
-      val choice2: Int = readInt()
+      val choice2: Int = StdIn.readInt()
       println("Entered CHOICE: "+choice2)
       if (choice2 == configsKeys.length + 1) {
         return
@@ -1497,7 +1497,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == sourceFiles.length + 1) {
         return
@@ -1529,7 +1529,7 @@ println("Getting Messages")
       seq += 1
       println("[" + seq + "] Main Menu")      
       print("\nEnter your choice: ")
-      val choice2: Int = readInt()
+      val choice2: Int = StdIn.readInt()
  
       if (choice2 == configsKeys.length + 1) {
         return
@@ -1588,7 +1588,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == pmmlFiles.length + 1) {
         return
@@ -1641,7 +1641,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == cfgFiles.length + 1) {
         return
@@ -1694,7 +1694,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == cfgFiles.length + 1) {
         return
@@ -1747,7 +1747,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == cfgFiles.length + 1) {
         return
@@ -1800,7 +1800,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == jarFiles.length + 1) {
         return
@@ -1852,7 +1852,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == functionFiles.length + 1) {
         return
@@ -1920,7 +1920,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == conceptFiles.length + 1) {
         return
@@ -1989,7 +1989,7 @@ println("Getting Messages")
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == typeFiles.length + 1) {
         return
@@ -2042,7 +2042,7 @@ println("Getting Messages")
         seq += 1
         println("[" + seq + "] Main Menu")
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice <= typeMenu.size) {
           selectedType = "com.ligadata.kamanja.metadata." + typeMenu(choice)
           done = true
@@ -2336,8 +2336,8 @@ println("Getting Messages")
 	      println("[" + seq + "] Main Menu")
 
 	      print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-	      //val choice:Int = readInt()
-	      val choicesStr: String = readLine()
+	      //val choice:Int = StdIn.readInt()
+	      val choicesStr: String = StdIn.readLine()
 
 	      var valid: Boolean = true
 	      var choices: List[Int] = List[Int]()
@@ -2413,7 +2413,7 @@ println("Getting Messages")
 	      println("[" + seq + "] Main Menu")
 
 	      print("\nEnter your choice: ")
-	      val choice: Int = readInt()
+	      val choice: Int = StdIn.readInt()
 
 	      if (choice == outputmsgFiles.length + 1)
 	        return
@@ -2451,7 +2451,7 @@ println("Getting Messages")
 	      outputMsgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
 	      print("\nEnter your choice: ")
-	      val choice: Int = readInt()
+	      val choice: Int = StdIn.readInt()
 
 	      if (choice < 1 || choice > outputMsgKeys.length) {
 	        println("Invalid choice " + choice + ",start with main menu...")
@@ -2606,7 +2606,7 @@ println("Getting Messages")
         for ((key, idx) <- topLevelMenu.zipWithIndex) { println("[" + (idx + 1) + "] " + key._1) }
         println("[" + (topLevelMenu.size + 1) + "] Exit")
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice <= topLevelMenu.size) {
           topLevelMenu(choice - 1)._2.apply
         } else if (choice == topLevelMenu.size + 1) {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ConceptService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ConceptService.scala
@@ -23,6 +23,9 @@ import com.ligadata.kamanja.metadata.AttributeDef
 
 import scala.io.Source
 import org.apache.logging.log4j._
+
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/13/15.
  */
@@ -101,7 +104,7 @@ object ConceptService {
           println("[" + srno + "] " + conceptKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > conceptKeys.length) {
           val errormsg = "Invalid choice " + choice + ". Start with the main menu."
@@ -203,7 +206,7 @@ object ConceptService {
       println("[" + srNo + "]" + message)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     //check if user input valid. If not exit
     for (userOption <- userOptions) {
       userOption match {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ConfigService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ConfigService.scala
@@ -22,6 +22,9 @@ import com.ligadata.MetadataAPI.MetadataAPIImpl
 
 import scala.io.Source
 import org.apache.logging.log4j._
+
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/13/15.
  */
@@ -152,7 +155,7 @@ object ConfigService {
       println("[" + srNo + "]" + message)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     //check if user input valid. If not exit
     for (userOption <- userOptions) {
       userOption match {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ContainerService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ContainerService.scala
@@ -23,6 +23,9 @@ import com.ligadata.MetadataAPI.{MetadataAPIImpl,ApiResult,ErrorCodeConstants}
 import scala.io.Source
 
 import org.apache.logging.log4j._
+
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/7/15.
  */
@@ -141,7 +144,7 @@ object ContainerService {
         println("["+srNo+"] "+containerKey)
       }
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > containerKeys.length) {
         response="Invalid choice " + choice + ",start with main menu..."
@@ -203,7 +206,7 @@ object ContainerService {
         contKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > contKeys.length) {
           return ("Invalid choice " + choice + ",start with main menu...")
@@ -246,7 +249,7 @@ object ContainerService {
       println("[" + srNo + "]" + container)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     //check if user input valid. If not exit
     for (userOption <- userOptions) {
       userOption match {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/FunctionService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/FunctionService.scala
@@ -22,6 +22,9 @@ import com.ligadata.MetadataAPI.MetadataAPIImpl
 
 import scala.io.Source
 import org.apache.logging.log4j._
+
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/12/15.
  */
@@ -99,7 +102,7 @@ object FunctionService {
           println("["+srno+"] "+functionKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > functionKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -146,7 +149,7 @@ object FunctionService {
           println("["+srno+"] "+functionKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > functionKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -252,7 +255,7 @@ object FunctionService {
       println("[" + srNo + "]" + model)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    var userOptions = Console.readLine().split(",")
+    var userOptions = StdIn.readLine().split(",")
     println("User selected the option(s) " + userOptions.length)
     //check if user input valid. If not exit
     for (userOption <- userOptions) {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/JarService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/JarService.scala
@@ -22,6 +22,9 @@ import com.ligadata.MetadataAPI.MetadataAPIImpl
 
 import scala.io.Source
 import org.apache.logging.log4j._
+
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/13/15.
  */
@@ -89,7 +92,7 @@ def uploadJar(input: String): String ={
     }
     
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     
     //check if user input valid. If not exit
     //for (userOption <- userOptions) {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/MessageService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/MessageService.scala
@@ -24,6 +24,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 import org.apache.logging.log4j._
 
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/7/15.
  */
@@ -169,7 +171,7 @@ object MessageService {
           println("[" + srno + "] " + messageKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > messageKeys.length) {
           val errormsg = "Invalid choice " + choice + ". Start with the main menu."
@@ -215,7 +217,7 @@ object MessageService {
         msgKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > msgKeys.length) {
           response = "Invalid choice " + choice + ",start with main menu..."
@@ -238,7 +240,7 @@ object MessageService {
 
     } catch {
       case e: Exception => {
-      e.getStackTraceString
+        e.getStackTrace.toString
       }
     }
   }
@@ -264,7 +266,7 @@ object MessageService {
       println("[" + srNo + "]" + message)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     //check if user input valid. If not exit
     for (userOption <- userOptions) {
       userOption match {
@@ -398,7 +400,7 @@ object MessageService {
           println("[" + srno + "] " + messageKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > outputMessageKeys.length) {
           val errormsg = "Invalid choice " + choice + ". Start with the main menu."
@@ -463,7 +465,7 @@ object MessageService {
       outputMessageKeys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > outputMessageKeys.length) {
         response = "Invalid choice " + choice + ",start with main menu..."

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ModelService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ModelService.scala
@@ -24,6 +24,8 @@ import scala.io.Source
 
 import org.apache.logging.log4j._
 
+import scala.io.StdIn
+
 /**
  * Created by dhaval on 8/7/15.
  */
@@ -194,7 +196,7 @@ object ModelService {
               println("[" + srNo + "]" + configkey)
             }
             print("\nEnter your choice: \n")
-            var userOption = Console.readInt()
+            var userOption = StdIn.readInt()
 
             userOption match {
               case x if ((1 to srNo).contains(userOption)) => {
@@ -280,7 +282,7 @@ object ModelService {
                 println("[" + srNo + "]" + configkey)
               }
               print("\nEnter your choice: \n")
-              var userOption = Console.readInt()
+              var userOption = StdIn.readInt()
 
               userOption match {
                 case x if ((1 to srNo).contains(userOption)) => {
@@ -326,7 +328,7 @@ object ModelService {
           println("["+srno+"] "+modelKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice < 1 || choice > modelKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
           response=errormsg
@@ -339,7 +341,7 @@ object ModelService {
 
     } catch {
       case e: Exception => {
-        response=e.getStackTraceString
+        response=e.getStackTrace.toString
       }
     }
     response
@@ -425,7 +427,7 @@ object ModelService {
               println("[" + srNo + "]" + configkey)
             }
             print("\nEnter your choice: \n")
-            var userOption = Console.readInt()
+            var userOption = StdIn.readInt()
  
             userOption match {
               case x if ((1 to srNo).contains(userOption)) => {
@@ -509,7 +511,7 @@ object ModelService {
               println("[" + srNo + "]" + configkey)
             }
             print("\nEnter your choice: \n")
-            var userOption = Console.readInt()
+            var userOption = StdIn.readInt()
 
             userOption match {
               case x if ((1 to srNo).contains(userOption)) => {
@@ -559,7 +561,7 @@ object ModelService {
           println("["+srno+"] "+modelKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > modelKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -605,7 +607,7 @@ object ModelService {
           println("["+srno+"] "+modelKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > modelKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -654,7 +656,7 @@ object ModelService {
           println("["+srno+"] "+modelKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > modelKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -697,7 +699,7 @@ object ModelService {
       println("[" + srNo + "]" + model)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    var userOptions = Console.readLine().split(",")
+    var userOptions = StdIn.readLine().split(",")
     println("User selected the option(s) " + userOptions.length)
     //check if user input valid. If not exit
     for (userOption <- userOptions) {

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/TypeService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/TypeService.scala
@@ -24,6 +24,9 @@ import scala.io.Source
 
 import org.apache.logging.log4j._
 
+import scala.io.StdIn
+
+
 /**
  * Created by dhaval on 8/12/15.
  */
@@ -103,7 +106,7 @@ object TypeService {
           println("["+srno+"] "+typeKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > typeKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -155,7 +158,7 @@ object TypeService {
           println("["+srno+"] "+modelKey)
         }
         println("Enter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
 
         if (choice < 1 || choice > typeKeys.length) {
           val errormsg="Invalid choice " + choice + ". Start with the main menu."
@@ -207,7 +210,7 @@ object TypeService {
         seq += 1
         println("[" + seq + "] Main Menu")
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice <= typeMenu.size) {
           selectedType = "com.ligadata.kamanja.metadata." + typeMenu(choice)
           done = true
@@ -249,7 +252,7 @@ object TypeService {
       println("[" + srNo + "]" + message)
     }
     print("\nEnter your choice(If more than 1 choice, please use commas to seperate them): \n")
-    val userOptions: List[Int] = Console.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
+    val userOptions: List[Int] = StdIn.readLine().filter(_ != '\n').split(',').filter(ch => (ch != null && ch != "")).map(_.trim.toInt).toList
     //check if user input valid. If not exit
     for (userOption <- userOptions) {
       userOption match {

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/MetadataAPIService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/MetadataAPIService.scala
@@ -250,7 +250,7 @@ trait MetadataAPIService extends HttpService {
         updateSourceModelService ! UpdateSourceModelService.UpdateScala(body)
       }catch {
         case e : Exception => {
-          logger.debug("Exception updating scala model "+e.getStackTraceString)
+          logger.debug("Exception updating scala model", e)
         }
       }
 

--- a/trunk/MetadataAPIServiceClient/src/main/scala/com/ligadata/metadataapiserviceclient/TestApiService.scala
+++ b/trunk/MetadataAPIServiceClient/src/main/scala/com/ligadata/metadataapiserviceclient/TestApiService.scala
@@ -510,7 +510,7 @@ object TestApiService {
       keys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > keys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -632,7 +632,7 @@ object TestApiService {
       keys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > keys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -690,7 +690,7 @@ object TestApiService {
       keys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > keys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -748,7 +748,7 @@ object TestApiService {
       keys.foreach(key => { seq += 1; println("[" + seq + "] " + key) })
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice < 1 || choice > keys.length) {
         println("Invalid choice " + choice + ",start with main menu...")
@@ -816,7 +816,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == pmmlFiles.length + 1) {
         return
@@ -859,8 +859,8 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -926,8 +926,8 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -993,7 +993,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == cfgFiles.length + 1) {
         return
@@ -1039,7 +1039,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == cfgFiles.length + 1) {
         return
@@ -1082,7 +1082,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == jarFiles.length + 1) {
         return
@@ -1128,7 +1128,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == functionFiles.length + 1) {
         return
@@ -1175,7 +1175,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == functionFiles.length + 1) {
         return
@@ -1223,7 +1223,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == conceptFiles.length + 1) {
         return
@@ -1275,7 +1275,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == conceptFiles.length + 1) {
         return
@@ -1323,7 +1323,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == typeFiles.length + 1) {
         return
@@ -1373,7 +1373,7 @@ object TestApiService {
         seq += 1
         println("[" + seq + "] Main Menu")
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice <= typeMenu.size) {
           selectedType = "com.ligadata.kamanja.metadata." + typeMenu(choice)
           done = true
@@ -1414,8 +1414,8 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choices (separate with commas if more than 1 choice given): ")
-      //val choice:Int = readInt()
-      val choicesStr: String = readLine()
+      //val choice:Int = StdIn.readInt()
+      val choicesStr: String = StdIn.readLine()
 
       var valid: Boolean = true
       var choices: List[Int] = List[Int]()
@@ -1484,7 +1484,7 @@ object TestApiService {
       println("[" + seq + "] Main Menu")
 
       print("\nEnter your choice: ")
-      val choice: Int = readInt()
+      val choice: Int = StdIn.readInt()
 
       if (choice == outputmsgFiles.length + 1)
         return
@@ -1606,7 +1606,7 @@ object TestApiService {
         for ((key, idx) <- topLevelMenu.zipWithIndex) { println("[" + (idx + 1) + "] " + key._1) }
         println("[" + (topLevelMenu.size + 1) + "] Exit")
         print("\nEnter your choice: ")
-        val choice: Int = readInt()
+        val choice: Int = StdIn.readInt()
         if (choice <= topLevelMenu.size) {
           topLevelMenu(choice - 1)._2.apply
         } else if (choice == topLevelMenu.size + 1) {

--- a/trunk/Pmml/MethodExtractor/src/main/scala/com/ligadata/udf/extract/UdfExtract.scala
+++ b/trunk/Pmml/MethodExtractor/src/main/scala/com/ligadata/udf/extract/UdfExtract.scala
@@ -187,9 +187,9 @@ object MethodExtract extends App with LogTrait {
       val clz1 = Class.forName(clsName + "$", true, udfLoaderInfo.loader)
       val clz1Sym = mirror.classSymbol(clz1)
       val istrait = clz1Sym.isTrait
-      val isabstract = clz1Sym.isAbstractClass
+      val isabstract = clz1Sym.isAbstract
       val clsType = clz1Sym.toType
-      val members = clsType.declarations
+      val members = clsType.decls
       members.filter(_.toString.startsWith("method")).foreach(m => mbrs += m)
     } catch {
       case e: Exception => {

--- a/trunk/Pmml/PmmlCompiler/src/main/scala/com/ligadata/pmml/fcnmacro/FunctionSelect.scala
+++ b/trunk/Pmml/PmmlCompiler/src/main/scala/com/ligadata/pmml/fcnmacro/FunctionSelect.scala
@@ -868,7 +868,7 @@ class FunctionSelect(val ctx : PmmlContext, val mgr : MdMgr, val node : xApply) 
 			  						/** take the first abstract class or trait */
 			  						val traitOrAbstractClasses : List[(String, ClassSymbol, Type)] = classesSuperClasseTriples.filter( triple => {
 			  							val (clssym, symbol, typ) : (String, ClassSymbol, Type) = triple
-						  				(symbol != null && (symbol.isAbstractClass || symbol.isTrait)) 
+						  				(symbol != null && (symbol.isAbstract || symbol.isTrait)) 
 			  						  
 			  						})
 			  						
@@ -1305,7 +1305,7 @@ class FunctionSelect(val ctx : PmmlContext, val mgr : MdMgr, val node : xApply) 
 							val clsSymbol = pmmlLoader.mirror.classSymbol(clz)
 							// Info about the class
 							val isTrait = clsSymbol.isTrait			 
-							val isAbstractClass = clsSymbol.isAbstractClass
+							val isAbstractClass = clsSymbol.isAbstract
 							val isModule = clsSymbol.isModule
 							val subclasses : Set[reflect.runtime.universe.Symbol] = clsSymbol.knownDirectSubclasses 
 							// Convert the class symbol into a Type
@@ -1388,7 +1388,7 @@ class FunctionSelect(val ctx : PmmlContext, val mgr : MdMgr, val node : xApply) 
 			  		breakable {
 			  			argTypeInfo.foreach( triple => {
 			  				val (clssym, symbol, typ) : (String, ClassSymbol, Type) = triple
-			  				if (symbol != null && (symbol.isAbstractClass || symbol.isTrait)) {
+			  				if (symbol != null && (symbol.isAbstract || symbol.isTrait)) {
 			  					newType = symbol.fullName
 			  					break
 			  				} else {
@@ -1461,7 +1461,7 @@ class FunctionSelect(val ctx : PmmlContext, val mgr : MdMgr, val node : xApply) 
 			val clsSymbol = pmmlLoader.mirror.classSymbol(clz)
 			// Info about the class
 			val isTrait = clsSymbol.isTrait			 
-			val isAbstractClass = clsSymbol.isAbstractClass
+			val isAbstractClass = clsSymbol.isAbstract
 			val isModule = clsSymbol.isModule
 			val subclasses : Set[reflect.runtime.universe.Symbol] = clsSymbol.knownDirectSubclasses 
 			// Convert the class symbol into a Type

--- a/trunk/Utils/CleanUtil/build.sbt
+++ b/trunk/Utils/CleanUtil/build.sbt
@@ -12,7 +12,7 @@ shellPrompt := { state =>  "sbt (%s)> ".format(Project.extract(state).currentPro
 
 libraryDependencies ++= Seq (
   "com.101tec" % "zkclient" % "0.6",
-  "org.apache.kafka" % "kafka_2.10" % "0.8.2.2",
+  "org.apache.kafka" %% "kafka" % "0.8.2.2",
   "org.apache.logging.log4j" % "log4j-core" % "2.4.1",
   "org.json4s" %% "json4s-native" % "{latestVersion}",
   "org.json4s" %% "json4s-jackson" % "{latestVersion}",

--- a/trunk/Utils/CleanUtil/src/main/scala/com/ligadata/utils/clean/CleanUtil.scala
+++ b/trunk/Utils/CleanUtil/src/main/scala/com/ligadata/utils/clean/CleanUtil.scala
@@ -156,7 +156,7 @@ object CleanUtil {
       case e: Exception => logger.error("Unexpected Exception caught", e)
     }
     finally {
-      if(config != null && config != "") {
+      if(config != null /* && config != "" */ ) {
         config.shutdown
       }
     }

--- a/trunk/Utils/Serialize/src/main/java/com/ligadata/Serialize/MetadataObjects.java
+++ b/trunk/Utils/Serialize/src/main/java/com/ligadata/Serialize/MetadataObjects.java
@@ -2810,7 +2810,7 @@ public final class MetadataObjects {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         initFields();
-        int mutable_bitField0_ = 0;
+        // int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -3776,7 +3776,7 @@ public final class MetadataObjects {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         initFields();
-        int mutable_bitField0_ = 0;
+        // int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -4516,7 +4516,7 @@ public final class MetadataObjects {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         initFields();
-        int mutable_bitField0_ = 0;
+        // int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -5254,7 +5254,7 @@ public final class MetadataObjects {
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
         initFields();
-        int mutable_bitField0_ = 0;
+        // int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {


### PR DESCRIPTION
Fixed most of the 2.11 warnings. There is one more type of warning which cause another 10-15 warnings. We will fix them later.

Fixed the following warnings
1. introduced new package scala.io.StdIn instead of Console to do IO operations
2. Fixed Some type library deprecated methods.

Also fixed the build.sbt for CleanUtil to have kafka built with 2.11 scala  and also fixed build.sbt for MQ Adapter to resolve local libraries for eclipse.