### PR TITLE
Pmml error message and api documentation true up.

### DIFF
--- a/trunk/FactoriesOfModelInstanceFactory/JpmmlFactoryOfModelInstanceFactory/src/main/scala/com/ligadata/jpmml/JpmmlFactoryOfModelInstanceFactory.scala
+++ b/trunk/FactoriesOfModelInstanceFactory/JpmmlFactoryOfModelInstanceFactory/src/main/scala/com/ligadata/jpmml/JpmmlFactoryOfModelInstanceFactory.scala
@@ -162,15 +162,15 @@ object JpmmlFactoryOfModelInstanceFactory extends FactoryOfModelInstanceFactory 
 }
 
 /**
-  * JpmmlAdapter serves a "shim" between the engine and a JPMML evaluator that will perform the actual message
+  * JpmmlAdapter serves a "shim" between the engine and a PMML evaluator that will perform the actual message
   * scoring. It exhibits the "adapter" pattern as discussed in "Design Patterns" by Gamma, Helm, Johnson, and Vlissitudes.
   *
   * Kamanja messages are presented to the adapter and transformed to a Map[FieldName, FieldValue] for consumption by
-  * the JPMML evaluator associated with the JpmmlAdapter instance. The target fields (or predictions) and the output fields
+  * the PMML evaluator associated with the JpmmlAdapter instance. The target fields (or predictions) and the output fields
   * are returned in the MappedModelResults instance to the engine for further transformation and dispatch.
   *
   * @param factory This model's factory object
-  * @param modelEvaluator The JPMML evaluator needed to evaluate the model for this model (modelName.modelVersion)
+  * @param modelEvaluator The PMML evaluator needed to evaluate the model for this model (modelName.modelVersion)
   */
 
 class JpmmlAdapter(factory : ModelInstanceFactory, modelEvaluator: ModelEvaluator[_]) extends ModelInstance(factory) {
@@ -204,7 +204,7 @@ class JpmmlAdapter(factory : ModelInstanceFactory, modelEvaluator: ModelEvaluato
     }
 
 
-    /** Since the JPMML decode util for the map results shows that at least one key can possibly be null,
+    /** Since the PMML decode util for the map results shows that at least one key can possibly be null,
       * let's give a name to it for our results.  This is likely just careful coding, but no harm
       * taking precaution.  This is the tag for the null field:
       */
@@ -235,7 +235,7 @@ class JpmmlAdapter(factory : ModelInstanceFactory, modelEvaluator: ModelEvaluato
       *
       * @param activeFields a List of the FieldNames
       * @param msg the incoming message instance
-      * @param evaluator the JPMML evaluator that the factory as arranged for this instance that can process the
+      * @param evaluator the PMML evaluator that the factory as arranged for this instance that can process the
       *                  input values.
       * @return
       */
@@ -256,7 +256,7 @@ class JpmmlAdapter(factory : ModelInstanceFactory, modelEvaluator: ModelEvaluato
 
 
 /**
-  * The JpmmlAdapterFactory instantiates its JPMML model instance when asked by caller.  Its main function is to
+  * The JpmmlAdapterFactory instantiates its PMML model instance when asked by caller.  Its main function is to
   * instantiate a new model whenever asked (createModelInstance) and assess whether the current message being processed
   * by the engine is consumable by this model (isValidMessage)
   *
@@ -346,10 +346,10 @@ class JpmmlAdapterFactory(modelDef: ModelDef, nodeContext: NodeContext) extends 
     }
 
     /**
-      * Create the appropriate JPMML evaluator based upon the pmml text supplied.
+      * Create the appropriate PMML evaluator based upon the pmml text supplied.
       *
-      * @param pmmlText the PMML (xml) text for a JPMML consumable model
-      * @return the appropriate JPMML ModelEvaluator
+      * @param pmmlText the PMML (xml) text for a PMML consumable model
+      * @return the appropriate PMML ModelEvaluator
       */
     private def createEvaluator(pmmlText : String) : ModelEvaluator[_] = {
 
@@ -376,7 +376,7 @@ class JpmmlAdapterFactory(modelDef: ModelDef, nodeContext: NodeContext) extends 
     override def createResultObject(): ModelResultBase = new MappedModelResults
 
     /**
-      *  Is the ModelInstance created by this ModelInstanceFactory is reusable? NOTE: All JPmml models are resusable.
+      *  Is the ModelInstance created by this ModelInstanceFactory is reusable? NOTE: All Pmml models are resusable.
       *
       *  @return true
       */

--- a/trunk/Metadata/src/main/scala/com/ligadata/kamanja/metadata/mdelems.scala
+++ b/trunk/Metadata/src/main/scala/com/ligadata/kamanja/metadata/mdelems.scala
@@ -745,11 +745,11 @@ object ModelRepresentation extends Enumeration {
 
 /**
  * The ModelDef provides meta data for all models in the system.  The model's input type can currently be either a jar or
- * a pmml text string (used by JPMML type models).  The mining model type is any of the dmg.org's model types as defined in their xsd or
+ * a pmml text string (used by PMML type models).  The mining model type is any of the dmg.org's model types as defined in their xsd or
  * one of our own special types (CustomScala, CustomJava, or Unknown when the caller does not supply one).
  *
  * Models, when marked with isReusable, can be cached (are considered idempotent)
- * @param modelRepresentation The form of model to be cataloged - JAR, JPMML etc.
+ * @param modelRepresentation The form of model to be cataloged - JAR, PMML etc.
  * @param miningModelType a MininingModelType default = "Unknown"
  * @param inputVars an array of the input variables that are consumed by this model (used for dag construction)
  * @param outputVars an array of the output variables published by this model (also used for dag construction)
@@ -758,7 +758,7 @@ object ModelRepresentation extends Enumeration {
  *                    any given model
  * @param supportsInstanceSerialization when true, ModelDef instances are serialized and cached for retrieval by
  *                                      the engine and other consumers of ModelDefs.  This mechanism is useful
- *                                      for JPMML and other models that are relatively expensive to initialize. The
+ *                                      for PMML and other models that are relatively expensive to initialize. The
  *                                      thinking here is that the ingestion will occur at 'add model' time just once
  *                                      and out of band from the cluster bootstrap.  FIXME: NOT IMPLEMENTED YET
  */

--- a/trunk/Metadata/src/main/scala/com/ligadata/kamanja/metadata/mdmgr.scala
+++ b/trunk/Metadata/src/main/scala/com/ligadata/kamanja/metadata/mdmgr.scala
@@ -2001,7 +2001,7 @@ class MdMgr {
 
   /**
    *   @deprecated("compatibility with old style model def...uses of this should be replaced with fully specified version","2015-10-15")
-   *  Construct and catalog a model definition.  NOTE: This function services old style ModelDef uses.  Particularly, PMML and JPMML are no
+   *  Construct and catalog a model definition.  NOTE: This function services old style ModelDef uses.  Particularly, PMML and KPMML are no
    *  longer using this method.  They now use the fully specified argument version.
    *
    *  @param nameSpace - the namespace in which this model should be cataloged
@@ -2020,7 +2020,7 @@ class MdMgr {
    *                   is being replaced).
    *  @param supportsInstanceSerialization when true, instances of this model are serialized and persisted in the metadata store, saving startup costs
    *                 required to prepare new instances.  NOTE: this feature is **not** implemented, but will prove useful for reducing
-   *                 cluster startup costs for JPMML models in particular.
+   *                 cluster startup costs for PMML models in particular.
    *  @return the ModelDef instance
    *
    */
@@ -2045,7 +2045,7 @@ class MdMgr {
                     , modelRep
                     , false /** isReusable */
                     , "" /** msgConsumed */
-                    , "" /** jpmml string */
+                    , "" /** pmml string */
                     , modelType
                     , inputVars: List[(String, String, String, String, Boolean, String)]
                     , outputVars: List[(String, String, String)]
@@ -2065,11 +2065,11 @@ class MdMgr {
    *  @param nameSpace - the namespace in which this model should be cataloged
    *  @param name - the name of the model.
    *  @param physicalName - the fully qualified className for the compiled model.
-   *  @param modelRep - the sort of model input this is (e.g., a Jar, a JPMML src string, et al)
+   *  @param modelRep - the sort of model input this is (e.g., a Jar, a PMML src string, et al)
    *  @param isReusable - can instances of this model be cached by the engine and reused on subsequent calls for same type?
-   *  @param msgConsumed - relevent for JPMML models, this is the full qualified name of the message from which content
-   *                     will be extracted for the jpmml evaluator
-   *  @param jpmmlStr - relevent for JPMML models, this is the actual xml PMML that is to be ingested by the JPMML evaluator factory
+   *  @param msgConsumed - relevent for PMML models, this is the full qualified name of the message from which content
+   *                     will be extracted for the pmml evaluator
+   *  @param jpmmlStr - relevent for PMML models, this is the actual xml PMML that is to be ingested by the PMML evaluator factory
    *  @param miningModelType :  a visual identifier that can be queried for and/or displayed. Values
    *                             for this currently include any of the dmg.org model types or our own types... any {BaselineModel, ClusteringModel,
    *                             GeneralRegressionModel, MiningModel, NaiveBayesModel, NearestNeighborModel, NeuralNetwork, RegressionModel,
@@ -2087,7 +2087,7 @@ class MdMgr {
    *                   is being replaced).
    *  @param supportsInstanceSerialization when true, instances of this model are serialized and persisted in the metadata store, saving startup costs
    *                 required to prepare new instances.  NOTE: this feature is **not** implemented, but will prove useful for reducing
-   *                 cluster startup costs for JPMML models in particular when it **is**.
+   *                 cluster startup costs for PMML models in particular when it **is**.
    *  @return the ModelDef instance
    *
    */
@@ -2162,7 +2162,7 @@ class MdMgr {
         if (depJars != null) depJarSet ++= depJars
         val dJars = if (depJarSet.size > 0) depJarSet.toArray else null
 
-        /** In the case of a JPMML model, save the string in the model representation now.  JPMML strings are
+        /** In the case of a PMML model, save the string in the model representation now.  PMML strings are
           * (for the first go) to be injested at the last possible minute by the shim model's factory object.
           * The instances so created will be cached for subsequent calls on the thread with which the instance
           * is associated.
@@ -2565,8 +2565,8 @@ class MdMgr {
     }
 
     funcDefs.addBinding(fn.FullName, fn)
-    compilerFuncDefs(fcnSig.toLowerCase()) = fn
     /** add it to the pmml compiler's typesignature based map as well */
+    compilerFuncDefs(fcnSig.toLowerCase()) = fn
 
   }
 
@@ -2636,8 +2636,8 @@ class MdMgr {
     fns.foreach(fn => {
       funcDefs.addBinding(fn.FullName, fn)
       val key = fn.typeString
-      compilerFuncDefs(key.toLowerCase()) = fn
       /** add it to the pmml compiler's typesignature based map as well */
+      compilerFuncDefs(key.toLowerCase()) = fn
     })
   }
 

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPI.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPI.scala
@@ -489,7 +489,7 @@ trait MetadataAPI {
     * @param input the text element to be added dependent upon the modelType specified.
     * @param userid the identity to be used by the security adapter to ascertain if this user has access permissions for this
     *               method. If Security and/or Audit are configured, this value must be a value other than None.
-    * @param modelName the namespace.name of the JPMML model to be added to the Kamanja metadata
+    * @param modelName the namespace.name of the PMML model to be added to the Kamanja metadata
     * @param version the model version to be used to describe this PMML model
     * @param msgConsumed the namespace.name of the message to be consumed by a PMML model
     * @return the result as a JSON String of object ApiResult where ApiResult.statusCode
@@ -526,7 +526,7 @@ trait MetadataAPI {
     * @param input the text element to be added dependent upon the modelType specified.
     * @param userid the identity to be used by the security adapter to ascertain if this user has access permissions for this
     *               method. If Security and/or Audit are configured, this value must be a value other than None
-    * @param modelName appropriate for PMML, the namespace.name of the JPMML model to be added to the Kamanja metadata
+    * @param modelName appropriate for PMML, the namespace.name of the PMML model to be added to the Kamanja metadata
     * @param version appropriate for PMML, the model version to be assigned. This version ''must'' be greater than the
     *                version in use and unique for models with the modelName
     * @param optVersionBeingUpdated not used .. reserved for future release where explicit modelnamespace.modelname.modelversion

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPIImpl.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/MetadataAPIImpl.scala
@@ -3625,8 +3625,8 @@ object MetadataAPIImpl extends MetadataAPI with LogTrait {
     /**
      * Add a PMML model to the metadata.
      *
-     * JPMML models are evaluated, not compiled. To create the model definition, an instance of the evaluator
-     * is obtained from the jpmml-evaluator component and the ModelDef is constructed and added to the store.
+     * PMML models are evaluated, not compiled. To create the model definition, an instance of the evaluator
+     * is obtained from the pmml-evaluator component and the ModelDef is constructed and added to the store.
      * @see com.ligadata.MetadataAPI.JpmmlSupport for more information
      *
      * @param modelName the namespace.name of the model to be injested.
@@ -3732,7 +3732,7 @@ object MetadataAPIImpl extends MetadataAPI with LogTrait {
   }
 
     /**
-     * Add Model (format XML)
+     * Add Kamanja PMML Model (format XML).  Kamanja Pmml models obtain their name and version from the header in the Pmml file.
      * @param pmmlText
      * @param userid the identity to be used by the security adapter to ascertain if this user has access permissions for this
      *               method. If Security and/or Audit are configured, this value must be a value other than None.
@@ -3763,7 +3763,7 @@ object MetadataAPIImpl extends MetadataAPI with LogTrait {
         apiResult
       } else {
         val reasonForFailure: String = if (modDef != null) ErrorCodeConstants.Add_Model_Failed_Higher_Version_Required else ErrorCodeConstants.Add_Model_Failed
-        val modDefName: String = if (modDef != null) modDef.FullName else "(pmml compile failed)"
+        val modDefName: String = if (modDef != null) modDef.FullName else "(kpmml compile failed)"
         val modDefVer: String = if (modDef != null) MdMgr.Pad0s2Version(modDef.Version) else MdMgr.UnknownVersion
         val apiResult = new ApiResult(ErrorCodeConstants.Failure, "AddModel", null, reasonForFailure + ":" + modDefName + "." + modDefVer)
         apiResult.toString()
@@ -3930,8 +3930,9 @@ object MetadataAPIImpl extends MetadataAPI with LogTrait {
      * @param input the text element to be added dependent upon the modelType specified.
      * @param optUserid the identity to be used by the security adapter to ascertain if this user has access permissions for this
      *               method.
-     * @param optModelName the namespace.name of the PMML model to be added to the Kamanja metadata
-     * @param optVersion the model version to be used to describe this PMML model
+     * @param optModelName the namespace.name of the PMML model to be added to the Kamanja metadata (Note: KPMML models extract this from
+     *                     the pmml source file header and for this reason is not required for the KPMML model types).
+     * @param optVersion the model version to be used to describe this PMML model (for KPMML types this value is obtained from the source file)
      * @param optVersionBeingUpdated not used .. reserved for future release where explicit modelnamespace.modelname.modelversion
      *                               can be updated (not just the latest version)
      * @return  result string indicating success or failure of operation
@@ -4300,22 +4301,22 @@ object MetadataAPIImpl extends MetadataAPI with LogTrait {
 
             } else {
                 val reasonForFailure: String = if (modDef != null) ErrorCodeConstants.Update_Model_Failed_Invalid_Version else ErrorCodeConstants.Update_Model_Failed
-                val modDefName: String = if (modDef != null) modDef.FullName else "(pmml compile failed)"
+                val modDefName: String = if (modDef != null) modDef.FullName else "(kpmml compile failed)"
                 val modDefVer: String = if (modDef != null) MdMgr.Pad0s2Version(modDef.Version) else MdMgr.UnknownVersion
-                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = PMML)", null, reasonForFailure + ":" + modDefName + "." + modDefVer)
+                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = KPMML)", null, reasonForFailure + ":" + modDefName + "." + modDefVer)
                 apiResult.toString()
             }
         } catch {
             case e: ObjectNotFoundException => {
                 val stackTrace = StackTrace.ThrowableTraceString(e)
                 logger.debug("\nStackTrace:" + stackTrace)
-                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = PMML)", null, "Error :" + e.toString() + ErrorCodeConstants.Update_Model_Failed)
+                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = KPMML)", null, "Error :" + e.toString() + ErrorCodeConstants.Update_Model_Failed)
                 apiResult.toString()
             }
             case e: Exception => {
                 val stackTrace = StackTrace.ThrowableTraceString(e)
                 logger.debug("\nStackTrace:" + stackTrace)
-                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = PMML)", null, "Error :" + e.toString() + ErrorCodeConstants.Update_Model_Failed)
+                var apiResult = new ApiResult(ErrorCodeConstants.Failure, s"UpdateModel(type = KPMML)", null, "Error :" + e.toString() + ErrorCodeConstants.Update_Model_Failed)
                 apiResult.toString()
             }
         }

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ModelService.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/ModelService.scala
@@ -237,7 +237,7 @@ object ModelService {
      * attempted if the SecurityAdapter instance deems the user worthy. Similarly if the AuditAdapter is supplied,
      * the userid will be logged there (recommended for production use).
      *
-     * NOTE: Jpmml models are distinct from the Kamanja Pmml model. At runtime, they use a PMML evaluator to interpret
+     * NOTE: Pmml models are distinct from the Kamanja Pmml model. At runtime, they use a PMML evaluator to interpret
      * the runtime representation of the PMML model. Kamanja models are compiled to Scala and then to Jars and executed
      * like the custom byte code models based upon Java or Scala.
      *
@@ -259,7 +259,7 @@ object ModelService {
                     , optMsgVersion: Option[String] = Some("-1")
                     ): String = {
         val response : String = if (input == "") {
-            val reply : String = "JPMML models are only ingested with command line arguments.. default directory selection is deprecated"
+            val reply : String = "PMML models are only ingested with command line arguments.. default directory selection is deprecated"
             logger.error(reply)
             null /// FIXME : we will return null for now and complain with first failure
         } else {
@@ -273,7 +273,7 @@ object ModelService {
                 val version : String = optVersion.getOrElse("no version supplied")
                 val msgConsumed : String = optMsgConsumed.getOrElse("no message supplied")
 
-                val reply : String = s"JPMML model definition ingestion has failed for model $modelName, version = $version, consumes msg = $msgConsumed user=$userId"
+                val reply : String = s"PMML model definition ingestion has failed for model $modelName, version = $version, consumes msg = $msgConsumed user=$userId"
                 logger.error(reply)
                 null /// FIXME : we will return null for now and complain with first failure/
             }
@@ -343,7 +343,7 @@ object ModelService {
     /**
      * Update a Kamanja Pmml model in the metadata with new pmml
      *
-     * @param input the path of the pmml model to be used for the update
+     * @param input the path of the Kamanja pmml model to be used for the update
      * @param userid the optional userId. If security and auditing in place this parameter is required.
      * @return the result of the operation
      */
@@ -374,7 +374,7 @@ object ModelService {
                 case option => {
                   var modelDefs = getUserInputFromMainMenu(models)
                   for (modelDef <- modelDefs)
-                    response = MetadataAPIImpl.UpdateModel(ModelType.PMML, modelDef.toString, userid)
+                    response = MetadataAPIImpl.UpdateModel(ModelType.KPMML, modelDef.toString, userid)
                 }
               }
 
@@ -391,7 +391,7 @@ object ModelService {
         var model = new File(input.toString)
         if (model.exists()) {
           modelDef = Source.fromFile(model).mkString
-          response = MetadataAPIImpl.UpdateModel(ModelType.PMML, modelDef, userid)
+          response = MetadataAPIImpl.UpdateModel(ModelType.KPMML, modelDef, userid)
         } else {
           response = "File does not exist"
         }
@@ -403,7 +403,7 @@ object ModelService {
   }
 
     /**
-      * Update a Jpmml model with the pmml text model found at ''pmmlPath''.  The model namespace, name and version
+      * Update a Pmml model with the pmml text model found at ''pmmlPath''.  The model namespace, name and version
       * are required.  The userid should have a valid value when authentication and auditing has been enabled on
       * the cluster.
       *
@@ -429,13 +429,13 @@ object ModelService {
                               , Some(newVersion))
       } catch {
         case fnf : FileNotFoundException => {
-            val msg : String = s"updateModelJPmml... supplied file path not found ... path = $pmmlPath"
+            val msg : String = s"updateModelPmml... supplied file path not found ... path = $pmmlPath"
             logger.error(msg)
             msg
         }
         case e : Exception => {
             val stackTrace = StackTrace.ThrowableTraceString(e)
-            val msg : String = if (pmmlPath == null) "updateModelJpmml pmml path was not supplied" else s"updateModelJPmml... exception e = ${e.toString}"
+            val msg : String = if (pmmlPath == null) "updateModelPmml pmml path was not supplied" else s"updateModelPmml... exception e = ${e.toString}"
             logger.error(s"$msg...stack = \n$stackTrace")
             msg
         }


### PR DESCRIPTION
There were a few remaining references to the jpmml in the source code in both the error messages
and the api documentation that has been added with the recent Jpmml revisions.  These have been
fixed.