### PR TITLE
Rest for pmml

### DIFF
--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
@@ -69,7 +69,7 @@ class AddModelService(requestContext: RequestContext, userid:Option[String], pas
       // Ok, if this is a KPMML model, we dont need any additional info for compilation, its all enclosed in the model.  for normal PMML,
       // we need to know ModelName, Version, and associated Message.  modelCompileInfo will be set if this is PMML, and not set if KPMML
       if (modelCompileInfo == None) {
-        looger.info ("No configuration information provided, assuming Kamanja PMML implementation.")
+        logger.info ("No configuration information provided, assuming Kamanja PMML implementation.")
         val apiResult = MetadataAPIImpl.AddModel(ModelType.KPMML, pmmlStr, userid)
         requestContext.complete(apiResult)
       } else {
@@ -80,11 +80,19 @@ class AddModelService(requestContext: RequestContext, userid:Option[String], pas
           requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: modelconfig is not specified, PMML model is required to have Model Compilation Information.").toString)
 
         val compileConfigTokens = cInfo.split(",")
-        if (compileConfigTokens.size < 3)
+        if (compileConfigTokens.size < 3  ||
+            compileConfigTokens.size > 4)
           requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs at least ModelName, ModelVersion, MessageConsumed.").toString)
 
-        val apiResult = MetadataAPIImpl.AddModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
-        requestContext.complete(apiResult)
+
+        if (compileConfigTokens.size == 3) {
+          val apiResult = MetadataAPIImpl.AddModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
+          requestContext.complete(apiResult)
+        } else {
+          val apiResult = MetadataAPIImpl.AddModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)), Some(compileConfigTokens(3)))
+          requestContext.complete(apiResult)
+        }
+
       }
     }
   }

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
@@ -37,7 +37,7 @@ object AddModelService {
   case class Process(pmmlStr:String)
 }
 
-class AddModelService(requestContext: RequestContext, userid:Option[String], password:Option[String], cert:Option[String]) extends Actor {
+class AddModelService(requestContext: RequestContext, userid:Option[String], password:Option[String], cert:Option[String], modelCompileInfo: Option[String]) extends Actor {
 
   import AddModelService._
   
@@ -66,8 +66,25 @@ class AddModelService(requestContext: RequestContext, userid:Option[String], pas
 	    MetadataAPIImpl.logAuditRec(userid,Some(AuditConstants.WRITE),AuditConstants.INSERTOBJECT,pmmlStr,AuditConstants.FAIL,"",nameVal)    
 	    requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null,  "Error:UPDATE not allowed for this user").toString )
     } else {
-      val apiResult = MetadataAPIImpl.AddModel(ModelType.KPMML, pmmlStr, userid, None)
-      requestContext.complete(apiResult)
+      // Ok, if this is a KPMML model, we dont need any additional info for compilation, its all enclosed in the model.  for normal PMML,
+      // we need to know ModelName, Version, and associated Message.  modelCompileInfo will be set if this is PMML, and not set if KPMML
+      if (modelCompileInfo == None) {
+        val apiResult = MetadataAPIImpl.AddModel(ModelType.KPMML, pmmlStr, userid)
+        requestContext.complete(apiResult)
+      } else {
+        val cInfo = modelCompileInfo.getOrElse("")
+
+        // Error if nothing specified in the modelCompileInfo
+        if (cInfo.equalsIgnoreCase(""))
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: modelconfig is not specified, PMML model is required to have Model Compilation Information.").toString)
+
+        val compileConfigTokens = cInfo.split(",")
+        if (compileConfigTokens.size != 3)
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs ModelName, ModelVersion, MessageName.").toString)
+
+        val apiResult = MetadataAPIImpl.AddModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
+        requestContext.complete(apiResult)
+      }
     }
   }
 }

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/AddModelService.scala
@@ -69,6 +69,7 @@ class AddModelService(requestContext: RequestContext, userid:Option[String], pas
       // Ok, if this is a KPMML model, we dont need any additional info for compilation, its all enclosed in the model.  for normal PMML,
       // we need to know ModelName, Version, and associated Message.  modelCompileInfo will be set if this is PMML, and not set if KPMML
       if (modelCompileInfo == None) {
+        looger.info ("No configuration information provided, assuming Kamanja PMML implementation.")
         val apiResult = MetadataAPIImpl.AddModel(ModelType.KPMML, pmmlStr, userid)
         requestContext.complete(apiResult)
       } else {
@@ -79,8 +80,8 @@ class AddModelService(requestContext: RequestContext, userid:Option[String], pas
           requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: modelconfig is not specified, PMML model is required to have Model Compilation Information.").toString)
 
         val compileConfigTokens = cInfo.split(",")
-        if (compileConfigTokens.size != 3)
-          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs ModelName, ModelVersion, MessageName.").toString)
+        if (compileConfigTokens.size < 3)
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs at least ModelName, ModelVersion, MessageConsumed.").toString)
 
         val apiResult = MetadataAPIImpl.AddModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
         requestContext.complete(apiResult)

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/MetadataAPIService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/MetadataAPIService.scala
@@ -48,17 +48,17 @@ trait MetadataAPIService extends HttpService {
   val logger = LogManager.getLogger(loggerName)
   // logger.setLevel(Level.TRACE);
 
-  val metadataAPIRoute = {
+  val metadataAPIRoute  = {
     optionalHeaderValueByName("userid") { userId => {
       optionalHeaderValueByName("password") { password => {
         optionalHeaderValueByName("role") {role =>
-          optionalHeaderValueByName("modelname")
-        { modelname =>
+          optionalHeaderValueByName("modelconfig")
+        { modelcofniginfo =>
           var user: Option[String] = None
 
           // Make sure that the Audit knows the difference between No User specified and an None (request originates within the engine)
           if (userId == None) user = Some("metadataapi")
-          logger.debug("userid => " + user.get + ",password => xxxxx" + ",role => " + role+",modelname => "+modelname)
+          logger.debug("userid => " + user.get + ",password => xxxxx" + ",role => " + role+",modelname => "+ modelcofniginfo)
           get {
               path("api" / Rest) { str => {
                 val toknRoute = str.split("/")
@@ -108,28 +108,29 @@ trait MetadataAPIService extends HttpService {
                     }
                   }
                 } else if (toknRoute(0).equalsIgnoreCase("Activate") || toknRoute(0).equalsIgnoreCase("Deactivate")) {
-                  entity(as[String]) { reqBody => requestContext => processPutRequest(toknRoute(0), toknRoute(1).toLowerCase, toknRoute(2), requestContext, user, password, role,modelname) }
+                  entity(as[String]) { reqBody => requestContext => processPutRequest(toknRoute(0), toknRoute(1).toLowerCase, toknRoute(2), requestContext, user, password, role, modelcofniginfo) }
                 } else {
                   entity(as[String]) { reqBody => {
-                    if (toknRoute.size == 1) { requestContext => processPutRequest(toknRoute(0), reqBody, requestContext, user, password, role,modelname) }
+                    if (toknRoute.size == 1) { requestContext => processPutRequest(toknRoute(0), reqBody, requestContext, user, password, role, modelcofniginfo) }
                       else if(toknRoute.size == 2 && toknRoute(0) == "model"){
                       ModelType.withName(toknRoute(1).toString) match {
                         case ModelType.KPMML => {
                           val objectType = toknRoute(0) + toknRoute(1)
-                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
+                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
 
                         }
                         case ModelType.JAVA => {
                           val objectType = toknRoute(0) + toknRoute(1)
-                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
+                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                         }
 
                         case ModelType.SCALA => {
                           val objectType = toknRoute(0) + toknRoute(1)
-                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
+                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                         }
                         case ModelType.PMML =>
-                          throw new RuntimeException("Not yet implemented")
+                          val objectType = toknRoute(0) + toknRoute(1)
+                          entity(as[String]) { reqBody => { requestContext => processPutRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                       }
                     }
                     else { requestContext => requestContext.complete((new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Unknown PUT route")).toString) }
@@ -147,26 +148,30 @@ trait MetadataAPIService extends HttpService {
                   if (toknRoute.size == 1) {
                     if (toknRoute(0).equalsIgnoreCase(GET_HEALTH)) 
                       requestContext => processHBRequest(reqBody, requestContext, user, password, role) 
-                    else
-                      entity(as[String]) { reqBody => { requestContext => processPostRequest(toknRoute(0), reqBody, requestContext, user, password, role,modelname) } }
-                  } else if (toknRoute.size == 2 && toknRoute(0) == "model") {
+                    else {
+                      if (toknRoute(0).equalsIgnoreCase("model"))
+                        logger.warn("MetadataAPI Http Service: URL of type https://hostname:port/api/model is deprecated")
+                      entity(as[String]) { reqBody => { requestContext => processPostRequest(toknRoute(0), reqBody, requestContext, user, password, role, modelcofniginfo) } }
+                    }
+                  } else if (toknRoute.size == 2 && toknRoute(0).equalsIgnoreCase("model")) {
                     ModelType.withName(toknRoute(1).toString) match {
                       case ModelType.KPMML => {
                         val objectType = toknRoute(0) + toknRoute(1)
-                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
-
+                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                       }
+
                       case ModelType.JAVA => {
                         val objectType = toknRoute(0) + toknRoute(1)
-                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
+                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                       }
 
                       case ModelType.SCALA => {
                         val objectType = toknRoute(0) + toknRoute(1)
-                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role,modelname) } }
+                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                       }
                       case ModelType.PMML =>
-                        throw new RuntimeException("Not implemented yet")
+                        val objectType = toknRoute(0) + toknRoute(1)
+                        entity(as[String]) { reqBody => { requestContext => processPostRequest(objectType, reqBody, requestContext, user, password, role, modelcofniginfo) } }
                     }
                   }
                   else { requestContext => requestContext.complete((new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Unknown POST route")).toString) }
@@ -195,14 +200,14 @@ trait MetadataAPIService extends HttpService {
   /**
    * Modify Existing objects in the Metadata
    */
-  private def processPutRequest(objtype: String, body: String, rContext: RequestContext, userid: Option[String], password: Option[String], role: Option[String], modelname: Option[String]): Unit = {
+  private def processPutRequest(objtype: String, body: String, rContext: RequestContext, userid: Option[String], password: Option[String], role: Option[String], modelcompileinfo: Option[String]): Unit = {
     val action = "Update" + objtype
     val notes = "Invoked " + action + " API "
     if (objtype.equalsIgnoreCase("Container")) {
       val updateContainerDefsService = actorRefFactory.actorOf(Props(new UpdateContainerService(rContext, userid, password, role)))
       updateContainerDefsService ! UpdateContainerService.Process(body)
     } else if (objtype.equalsIgnoreCase("Model")) {
-      val updateModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateModelService(rContext, userid, password, role)))
+      val updateModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateModelService(rContext, userid, password, role, None)))
       updateModelService ! UpdateModelService.Process(body)
     } else if (objtype.equalsIgnoreCase("Message")) {
       val updateMessageDefsService = actorRefFactory.actorOf(Props(new UpdateMessageService(rContext, userid, password, role)))
@@ -226,36 +231,32 @@ trait MetadataAPIService extends HttpService {
       val updateOutputMsgDefService = actorRefFactory.actorOf(Props(new UpdateOutputMsgService(rContext, userid, password, role)))
       updateOutputMsgDefService ! UpdateOutputMsgService.Process(body, "JSON")
     }else if (objtype.equalsIgnoreCase("UploadModelConfig")) {
-      //TODO
-      //call the UploadModelConfig in the MetadataAPIImpl
-      //UploadModelsConfig (cfgStr: String,userid:Option[String], objectList: String): String = {
       logger.debug("In put request process of UploadModelConfig")
       val addModelDefsService = actorRefFactory.actorOf(Props(new UploadModelConfigService(rContext, userid, password, role)))
       addModelDefsService ! UploadModelConfigService.Process(body)
     } else if (objtype.equalsIgnoreCase("modeljava")) {
-      //TODO
       logger.debug("In put request process of model java")
-
-          val updateSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateSourceModelService(rContext, userid, password, role,modelname)))
+      val updateSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateSourceModelService(rContext, userid, password, role, modelcompileinfo)))
       updateSourceModelService ! UpdateSourceModelService.UpdateJava(body)
 
     }
     else if (objtype.equalsIgnoreCase("modelscala")) {
-      //TODO
-      try{
-        logger.debug("In put request process of model scala")
-        // rContext.complete(new ApiResult(ErrorCodeConstants.Success, "AddModelFromScalaSource",body.toString, "Upload of java model successful").toString)
-        val updateSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateSourceModelService(rContext, userid, password, role,modelname)))
+      try {
+        val updateSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateSourceModelService(rContext, userid, password, role, modelcompileinfo)))
         updateSourceModelService ! UpdateSourceModelService.UpdateScala(body)
-      }catch {
-        case e : Exception => {
+      } catch {
+        case e: Exception => {
           logger.debug("Exception updating scala model", e)
         }
       }
 
     }
     else if (objtype.equalsIgnoreCase("modelkpmml")) {
-      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateModelService(rContext, userid, password, role)))
+      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateModelService(rContext, userid, password, role, None)))
+      addModelService ! UpdateModelService.Process(body)
+    }
+    else if (objtype.equalsIgnoreCase("modelpmml")) {
+      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new UpdateModelService(rContext, userid, password, role, modelcompileinfo)))
       addModelService ! UpdateModelService.Process(body)
     }
     else {
@@ -285,14 +286,14 @@ trait MetadataAPIService extends HttpService {
   /**
    * Create new Objects in the Metadata
    */
-  private def processPostRequest(objtype: String, body: String, rContext: RequestContext, userid: Option[String], password: Option[String], role: Option[String],modelname: Option[String]): Unit = {
+  private def processPostRequest(objtype: String, body: String, rContext: RequestContext, userid: Option[String], password: Option[String], role: Option[String], modelcompileinfo: Option[String]): Unit = {
     val action = "Add" + objtype
     val notes = "Invoked " + action + " API "
     if (objtype.equalsIgnoreCase("Container")) {
       val addContainerDefsService = actorRefFactory.actorOf(Props(new AddContainerService(rContext, userid, password, role)))
       addContainerDefsService ! AddContainerService.Process(body)
     } else if (objtype.equalsIgnoreCase("Model")) {
-      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new AddModelService(rContext, userid, password, role)))
+      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new AddModelService(rContext, userid, password, role, None)))
       addModelService ! AddModelService.Process(body)
     } else if (objtype.equalsIgnoreCase("Message")) {
       val addMessageDefsService = actorRefFactory.actorOf(Props(new AddMessageService(rContext, userid, password, role)))
@@ -320,20 +321,23 @@ trait MetadataAPIService extends HttpService {
       //TODO
       logger.debug("In post request process of model java")
 
-      val addSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new AddSourceModelService(rContext, userid, password, role,modelname)))
+      val addSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new AddSourceModelService(rContext, userid, password, role, modelcompileinfo)))
       addSourceModelService ! AddSourceModelService.ProcessJava(body)
 
     }
     else if (objtype.equalsIgnoreCase("modelscala")) {
-      //TODO
+
       logger.debug("In post request process of model scala")
-     // rContext.complete(new ApiResult(ErrorCodeConstants.Success, "AddModelFromScalaSource",body.toString, "Upload of java model successful").toString)
-     val addSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new AddSourceModelService(rContext, userid, password, role,modelname)))
+      // rContext.complete(new ApiResult(ErrorCodeConstants.Success, "AddModelFromScalaSource",body.toString, "Upload of java model successful").toString)
+      val addSourceModelService: ActorRef = actorRefFactory.actorOf(Props(new AddSourceModelService(rContext, userid, password, role, modelcompileinfo)))
       addSourceModelService ! AddSourceModelService.ProcessScala(body)
-     
     }
     else if (objtype.equalsIgnoreCase("modelkpmml")) {
-      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new AddModelService(rContext, userid, password, role)))
+      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new AddModelService(rContext, userid, password, role, None)))
+      addModelService ! AddModelService.Process(body)
+    }
+    else if (objtype.equalsIgnoreCase("modelpmml")) {
+      val addModelService: ActorRef = actorRefFactory.actorOf(Props(new AddModelService(rContext, userid, password, role, modelcompileinfo)))
       addModelService ! AddModelService.Process(body)
     }
     else {

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/UpdateModelService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/UpdateModelService.scala
@@ -32,7 +32,7 @@ object UpdateModelService {
   case class Process(pmmlStr:String)
 }
 
-class UpdateModelService(requestContext: RequestContext, userid:Option[String], password:Option[String], cert:Option[String]) extends Actor {
+class UpdateModelService(requestContext: RequestContext, userid:Option[String], password:Option[String], cert:Option[String], modelCompileInfo: Option[String]) extends Actor {
 
   import UpdateModelService._
   
@@ -57,8 +57,26 @@ class UpdateModelService(requestContext: RequestContext, userid:Option[String], 
        MetadataAPIImpl.logAuditRec(userid,Some(AuditConstants.WRITE),AuditConstants.UPDATEOBJECT,pmmlStr,AuditConstants.FAIL,"",nameVal)
       requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error:UPDATE not allowed for this user").toString )
     } else {
-      val apiResult = MetadataAPIImpl.UpdateModel(ModelType.KPMML, pmmlStr, userid)
-      requestContext.complete(apiResult)      
+
+      // Ok, if this is a KPMML model, we dont need any additional info for compilation, its all enclosed in the model.  for normal PMML,
+      // we need to know ModelName, Version, and associated Message.  modelCompileInfo will be set if this is PMML, and not set if KPMML
+      if (modelCompileInfo == None) {
+        val apiResult = MetadataAPIImpl.UpdateModel(ModelType.KPMML, pmmlStr, userid)
+        requestContext.complete(apiResult)
+      } else {
+        val cInfo = modelCompileInfo.getOrElse("")
+
+        // Error if nothing specified in the modelCompileInfo
+        if (cInfo.equalsIgnoreCase(""))
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: modelconfig is not specified, PMML model is required to have Model Compilation Information.").toString)
+
+        val compileConfigTokens = cInfo.split(",")
+        if (compileConfigTokens.size != 3)
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs ModelName, ModelVersion, MessageName.").toString)
+
+        val apiResult = MetadataAPIImpl.UpdateModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
+        requestContext.complete(apiResult)
+      }
     }
   }
 }

--- a/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/UpdateModelService.scala
+++ b/trunk/MetadataAPIService/src/main/scala/com/ligadata/metadataapiservice/UpdateModelService.scala
@@ -61,6 +61,7 @@ class UpdateModelService(requestContext: RequestContext, userid:Option[String], 
       // Ok, if this is a KPMML model, we dont need any additional info for compilation, its all enclosed in the model.  for normal PMML,
       // we need to know ModelName, Version, and associated Message.  modelCompileInfo will be set if this is PMML, and not set if KPMML
       if (modelCompileInfo == None) {
+        looger.info ("No configuration information provided, assuming Kamanja PMML implementation.")
         val apiResult = MetadataAPIImpl.UpdateModel(ModelType.KPMML, pmmlStr, userid)
         requestContext.complete(apiResult)
       } else {
@@ -71,8 +72,8 @@ class UpdateModelService(requestContext: RequestContext, userid:Option[String], 
           requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: modelconfig is not specified, PMML model is required to have Model Compilation Information.").toString)
 
         val compileConfigTokens = cInfo.split(",")
-        if (compileConfigTokens.size != 3)
-          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs ModelName, ModelVersion, MessageName.").toString)
+        if (compileConfigTokens.size < 2)
+          requestContext.complete(new ApiResult(ErrorCodeConstants.Failure, APIName, null, "Error: Invalid compile config paramters specified for PMML, Needs  ModelName, ModelVersion, Optional[UpdateModelVersion].").toString)
 
         val apiResult = MetadataAPIImpl.UpdateModel(ModelType.PMML, pmmlStr, userid, Some(compileConfigTokens(0)), Some(compileConfigTokens(1)), Some(compileConfigTokens(2)))
         requestContext.complete(apiResult)


### PR DESCRIPTION
@ligadata-william 


Here are my results:



danielkozin$ curl -X POST -k  https://localhost:8081/api/model/pmml -d @'/Users/danielkozin/kamanjaApps/JpmmlExample/DecisionTreeEnsembleIris.pmml' --header "modelconfig:system.Model1,1.0.0,system.irismsg"
{
  "APIResults" : {
    "Status Code" : 0,
    "Function Name" : "AddModel",
    "Result Data" : null,
    "Result Description" : "Model Added Successfully:system.model1.000001000000000000"
  }
}

**INVALID HEADER (MISSING 3 required fields for PMML)**
danielkozin$ curl -X POST -k  https://localhost:8081/api/model/pmml -d @'/Users/danielkozin/kamanjaApps/JpmmlExample/DecisionTreeEnsembleIris.pmml' --header "modelconfig:system.Model1,1.0.0"
{
  "APIResults" : {
    "Status Code" : -1,
    "Function Name" : "AddModelService",
    "Result Data" : null,
    "Result Description" : "Error: Invalid compile config paramters specified for PMML, Needs ModelName, ModelVersion, MessageName."
  }
}



**if no HEADER is passed it, the code will assume KPMML implementation, and I see**

 danielkozin$ curl -X POST -k  https://localhost:8081/api/model/pmml -d @'/Users/danielkozin/kamanjaApps/JpmmlExample/DecisionTreeEnsembleIris.pmml'
{
  "APIResults" : {
    "Status Code" : -1,
    "Function Name" : "AddModel",
    "Result Data" : null,
    "Result Description" : "Error :com.ligadata.Exceptions.ModelCompilationFailedException: key not found: ClassNameFailed to Add Model"
  }
}