### PR TITLE
Kamanja 335

### DIFF
--- a/trunk/Exceptions/src/main/resources/Version.txt
+++ b/trunk/Exceptions/src/main/resources/Version.txt
@@ -1,1 +1,1 @@
-Kamanja version 1.3.0
+Kamanja version 1.3.2

--- a/trunk/FactoriesOfModelInstanceFactory/JarFactoryOfModelInstanceFactory/src/main/scala/com/ligadata/FactoryOfModelInstanceFactory/JarFactoryOfModelInstanceFactory.scala
+++ b/trunk/FactoriesOfModelInstanceFactory/JarFactoryOfModelInstanceFactory/src/main/scala/com/ligadata/FactoryOfModelInstanceFactory/JarFactoryOfModelInstanceFactory.scala
@@ -20,7 +20,6 @@ import com.ligadata.kamanja.metadata.{ ModelDef, BaseElem }
 import com.ligadata.KamanjaBase._
 import com.ligadata.Utils.{ Utils, KamanjaClassLoader, KamanjaLoaderInfo }
 import org.apache.logging.log4j.{ Logger, LogManager }
-import com.ligadata.Exceptions.StackTrace
 
 object JarFactoryOfModelInstanceFactory extends FactoryOfModelInstanceFactory {
   private[this] val loggerName = this.getClass.getName()
@@ -71,14 +70,15 @@ object JarFactoryOfModelInstanceFactory extends FactoryOfModelInstanceFactory {
           isModel = Utils.isDerivedFrom(curClz, "com.ligadata.KamanjaBase.ModelBaseObj")
           if (isModel == false)
             curClz = curClz.getSuperclass()
-          else
+          else {
             isModelBaseObj = true
+            LOG.debug("Found ModelBaseObj class:" + clsName)
+          }
         }
       }
     } catch {
       case e: Exception => {
-        val stackTrace = StackTrace.ThrowableTraceString(e)
-        LOG.error("Failed to get classname %s. Reason:%s, Cause:%s\nStackTrace:%s".format(clsName, e.getMessage, e.getCause, stackTrace))
+        LOG.error("Failed to get classname %s".format(clsName), e)
         return null
       }
     }
@@ -91,44 +91,51 @@ object JarFactoryOfModelInstanceFactory extends FactoryOfModelInstanceFactory {
             var mdlBaseObjInst: Any = null
             try {
               // Trying Singleton Object
+              LOG.debug("Creating mdlBaseObjInst")
               val module = metadataLoader.mirror.staticModule(clsName)
               val obj = metadataLoader.mirror.reflectModule(module)
               mdlBaseObjInst = obj.instance
+              LOG.debug("Created mdlBaseObjInst:" + mdlBaseObjInst)
             } catch {
               case e: Exception => {
+                LOG.debug("Creating mdlBaseObjInst")
                 // Trying Regular Object instantiation
                 mdlBaseObjInst = curClass.newInstance
+                LOG.debug("Created mdlBaseObjInst:" + mdlBaseObjInst)
               }
             }
 
-            if (objinst.isInstanceOf[ModelBaseObj]) {
-              val modelBaseobj = objinst.asInstanceOf[ModelBaseObj]
+            if (mdlBaseObjInst.isInstanceOf[ModelBaseObj]) {
+              LOG.debug("Getting modelBaseobj")
+              val modelBaseobj = mdlBaseObjInst.asInstanceOf[ModelBaseObj]
+              LOG.debug("Got modelBaseobj:" + modelBaseobj)
               objinst = new ModelBaseObjMdlInstanceFactory(mdl, nodeContext, modelBaseobj)
+              LOG.debug("Got objinst:" + objinst)
             }
           } else {
+            LOG.debug("Getting objinst")
             // Trying Regular class instantiation
             objinst = curClass.getConstructor(classOf[ModelDef], classOf[NodeContext]).newInstance(mdl, nodeContext)
+            LOG.debug("Got objinst:" + objinst)
           }
         } catch {
           case e: Exception => {
-            val stackTrace = StackTrace.ThrowableTraceString(e)
-            LOG.error("Failed to instantiate ModelInstanceFactory. Reason:%s, Cause:%s\nStackTrace:%s".format(e.getMessage, e.getCause, stackTrace))
+            LOG.error("Failed to instantiate ModelInstanceFactory. clsName:" + clsName, e)
             return null
           }
         }
 
-        if (objinst.isInstanceOf[ModelInstanceFactory]) {
+        if (objinst != null && objinst.isInstanceOf[ModelInstanceFactory]) {
           val modelobj = objinst.asInstanceOf[ModelInstanceFactory]
           val mdlName = (mdl.NameSpace.trim + "." + mdl.Name.trim).toLowerCase
           LOG.info("Created Model:" + mdlName)
           return modelobj
         }
-        LOG.error("Failed to instantiate ModelInstanceFactory :" + clsName + ". ObjType0:" + objinst.getClass.getSimpleName + ". ObjType1:" + objinst.getClass.getCanonicalName)
+        LOG.error("Failed to instantiate ModelInstanceFactory :" + clsName + ". ObjType0:" + objinst.getClass.getSimpleName + ". ObjType1:" + (if (objinst != null) objinst.getClass.getCanonicalName else ""))
         return null
       } catch {
         case e: Exception =>
-          val stackTrace = StackTrace.ThrowableTraceString(e)
-          LOG.error("Failed to instantiate ModelInstanceFactory for classname:%s. Reason:%s, Cause:%s\nStackTrace:%s".format(clsName, e.getMessage, e.getCause, stackTrace))
+          LOG.error("Failed to instantiate ModelInstanceFactory for classname:%s.".format(clsName), e)
           return null
       }
     }

--- a/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
+++ b/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
@@ -18,14 +18,11 @@
 package com.ligadata.KamanjaBase
 
 import scala.collection.immutable.Map
-import com.ligadata.Utils.Utils
 import com.ligadata.kamanja.metadata.{ MdMgr, ModelDef }
-import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import java.io.{ DataInputStream, DataOutputStream }
-import com.ligadata.KvBase.{ TimeRange }
-import com.ligadata.KvBase.{ Key, Value, TimeRange /* , KvBaseDefalts, KeyWithBucketIdAndPrimaryKey, KeyWithBucketIdAndPrimaryKeyCompHelper */ }
+import com.ligadata.KvBase.{ Key, TimeRange }
 import com.ligadata.Utils.{ KamanjaLoaderInfo }
 import com.ligadata.HeartBeat._
 
@@ -42,8 +39,6 @@ object MinVarType extends Enumeration {
     }
   }
 }
-
-import MinVarType._
 
 case class Result(val name: String, val result: Any)
 

--- a/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
+++ b/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
@@ -453,3 +453,24 @@ class NodeContext(val gCtx: EnvContext) {
   def getValue(key: String): Any = { valuesMap.get(key) }
 }
 
+// 1.1.x compatible models for execution purpose without changing much in the execution path -- Begin
+class ModelBaseMdlInstance(factory: ModelBaseObjMdlInstanceFactory) extends ModelInstance(factory.asInstanceOf[ModelInstanceFactory]) {
+  override def execute(txnCtxt: TransactionContext, outputDefault: Boolean): ModelResultBase = {
+    val modelContext = new ModelContext(txnCtxt, txnCtxt.getMessage())
+    val mdlInst = factory.mdlBaseObj.CreateNewModel(modelContext)
+    mdlInst.execute(outputDefault)
+  }
+}
+
+class ModelBaseObjMdlInstanceFactory(modelDef: ModelDef, nodeContext: NodeContext, val mdlBaseObj: ModelBaseObj) extends ModelInstanceFactory(modelDef, nodeContext)  {
+  override def getModelName() = mdlBaseObj.ModelName() // Model Name
+
+  override def getVersion() = mdlBaseObj.Version() // Model Version
+
+  override def isValidMessage(msg: MessageContainerBase): Boolean = mdlBaseObj.IsValidMessage(msg)
+
+  override def createModelInstance() = new ModelBaseMdlInstance(this)
+
+  override def createResultObject() = mdlBaseObj.CreateResultObject()
+}
+// 1.1.x compatible models for execution purpose without changing much in the execution path -- End

--- a/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
+++ b/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
@@ -18,11 +18,13 @@
 package com.ligadata.KamanjaBase
 
 import scala.collection.immutable.Map
+import com.ligadata.Utils.Utils
 import com.ligadata.kamanja.metadata.{ MdMgr, ModelDef }
+import org.json4s._
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import java.io.{ DataInputStream, DataOutputStream }
-import com.ligadata.KvBase.{ Key, TimeRange }
+import com.ligadata.KvBase.{ Key, Value, TimeRange /* , KvBaseDefalts, KeyWithBucketIdAndPrimaryKey, KeyWithBucketIdAndPrimaryKeyCompHelper */ }
 import com.ligadata.Utils.{ KamanjaLoaderInfo }
 import com.ligadata.HeartBeat._
 
@@ -39,6 +41,8 @@ object MinVarType extends Enumeration {
     }
   }
 }
+
+import MinVarType._
 
 case class Result(val name: String, val result: Any)
 

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/CompilerProxy.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/CompilerProxy.scala
@@ -863,7 +863,9 @@ class CompilerProxy {
 
       var isModel = false
       while (curClz != null && isModel == false) {
-        isModel = Utils.isDerivedFrom(curClz, "com.ligadata.KamanjaBase.ModelInstanceFactory")
+        isModel = Utils.isDerivedFrom(curClz, "com.ligadata.KamanjaBase.ModelInstanceFactory") || 
+		           Utils.isDerivedFrom(curClz, "com.ligadata.KamanjaBase.ModelBaseObj")
+
         if (isModel == false)
           curClz = curClz.getSuperclass()
       }

--- a/trunk/SampleApplication/HelloWorld/model/HelloWorld.scala
+++ b/trunk/SampleApplication/HelloWorld/model/HelloWorld.scala
@@ -17,7 +17,6 @@
 package com.ligadata.samples.models
 
 import com.ligadata.KamanjaBase._
-import com.ligadata.KvBase.TimeRange
 import com.ligadata.kamanja.metadata.ModelDef;
 
 class HelloWorldModelFactory(modelDef: ModelDef, nodeContext: NodeContext) extends ModelInstanceFactory(modelDef, nodeContext) {

--- a/trunk/SampleApplication/InterfacesSamples/src/main/resources/sample-app/metadata/model/LowBalanceAlert_Finance.scala
+++ b/trunk/SampleApplication/InterfacesSamples/src/main/resources/sample-app/metadata/model/LowBalanceAlert_Finance.scala
@@ -17,7 +17,6 @@
 package com.ligadata.models.samples.models
 
 import com.ligadata.KamanjaBase._
-import com.ligadata.KvBase.TimeRange
 import RddUtils._
 import RddDate._
 import org.json4s._

--- a/trunk/SampleApplication/Telecom/metadata/model/SubscriberUsageAlert_Telecom.scala
+++ b/trunk/SampleApplication/Telecom/metadata/model/SubscriberUsageAlert_Telecom.scala
@@ -34,7 +34,7 @@
 //     
 package com.ligadata.models.samples.models
 
-import com.ligadata.KvBase.{ Key, Value, TimeRange }
+import com.ligadata.KvBase.{ Key, Value }
 import com.ligadata.KamanjaBase._
 import RddUtils._
 import RddDate._


### PR DESCRIPTION
Hi,

These changes should handle 1.1.x models as it is in 1.3.x with the following exceptions

1) Make sure we did not have the following imports in 1.1.x models, still they should work fine without any issues
	a) com.ligadata.KamanjaBase.TimeRange (as far as I know we are not using it, may be importing it)
	b) System.*;
	c) com.ligadata.messagescontainers._
	d) com.ligadata.messagescontainers.System._
2) If Log4j used in models, it must need to have log4j-1.2.17.jar as dependency in Model Compile Config. If we have any other version it need to be uploaded to system first.

These exceptions should work in 1.1.x also as it is. But we should not have any imports which are not really necessary.
