### PR TITLE
Funneling all calls to class KamanjaManager through object KamanjaMan…

### DIFF
--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/ExecContext.scala
@@ -120,9 +120,9 @@ class ExecContextImpl(val input: InputAdapter, val curPartitionKey: PartitionUni
 
   protected override def commitData(txnCtxt: TransactionContext): Unit = {
     try {
-      val adapterChngCntr = KamanjaManager.getAdapterChangedCntr
+      val adapterChngCntr = KamanjaManager.instance.getAdapterChangedCntr
       if (adapterChngCntr != adapterChangedCntr) {
-        val (ins, outs, storages, cntr) = KamanjaManager.getAllAdaptersInfo
+        val (ins, outs, storages, cntr) = KamanjaManager.instance.getAllAdaptersInfo
         adapterChangedCntr = cntr
 
         val mdMgr = GetMdMgr

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaMdCfg.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaMdCfg.scala
@@ -475,7 +475,7 @@ object KamanjaMdCfg {
         if (adapter == null) return false
         adapter.setObjectResolver(KamanjaMetadata)
         storageAdapters += adapter
-        KamanjaManager.incrAdapterChangedCntr()
+        KamanjaManager.instance.incrAdapterChangedCntr()
       } catch {
         case e: Exception => {
           LOG.error("Failed to get output adapter for %s".format(ac), e)
@@ -594,7 +594,7 @@ object KamanjaMdCfg {
         if (adapter == null) return false
         adapter.setObjectResolver(KamanjaMetadata)
         outputAdapters += adapter
-        KamanjaManager.incrAdapterChangedCntr()
+        KamanjaManager.instance.incrAdapterChangedCntr()
       } catch {
         case e: Exception => {
           LOG.error("Failed to get output adapter for %s".format(ac), e)
@@ -713,7 +713,7 @@ object KamanjaMdCfg {
         val adapter = CreateInputAdapterFromConfig(conf, execCtxtObj, nodeContext)
         if (adapter == null) return false
         inputAdapters += adapter
-        KamanjaManager.incrAdapterChangedCntr()
+        KamanjaManager.instance.incrAdapterChangedCntr()
       } catch {
         case e: Exception => {
           LOG.error("Failed to get input adapter for %s.".format(ac), e)


### PR DESCRIPTION
I've made some changes to funnel all access to KamanjaManager through its companion object. A val instance has been created which will return a new KamanjaManager if one hasn't been created yet.

def run has been made private so only KamanjaManager.main can start it. I'm a bit iffy on this particular one. If I can integrate DockerManager into the tests, then it won't matter but this move makes running an in-proc cluster unavailable (which isn't preferable anyway). Feedback welcome.