### PR TITLE
Kamanja 1035 Alternate command parser and help menu update

### DIFF
--- a/trunk/MetadataAPI/src/main/resources/HelpMenu.txt
+++ b/trunk/MetadataAPI/src/main/resources/HelpMenu.txt
@@ -41,24 +41,24 @@ kamanja upload cluster config input(optional)
 kamanja upload compile config input(optional)
 kamanja dump all cfg objects
 kamanja remove engine config
-IX. Jar operations
+VII. Jar operations
 kamanja upload jar
-X. Cluster, metadata and adapter operations
+VIII. Cluster, metadata and adapter operations
 kamanja dump metadata
 kamanja dump all nodes
 kamanja dump all clusters
 kamanja dump all cluster cfgs
 kamanja dump all adapters
-XII. Kamanja engine operations
+IX. Kamanja engine operations
 kamanja start
 kamanja start -v (for verbose)
-XIII. Topic operations
+X. Topic operations
 kamanja watch status queue
 kamanja push data
 kamanja create queues
-XIV. Web service
+XI. Web service
 kamanja start webservice
-XV. Adapter Message Bindings
+XII. Adapter Message Bindings
 kamanja add adaptermessagebinding FROMFILE input
 kamanja add adaptermessagebinding FROMSTRING input
 kamanja remove adaptermessagebinding KEY '<adapter name>,<namespace.msgname>,<namespace.serializername>'
@@ -68,5 +68,5 @@ kamanja list adaptermessagebindings MESSAGEFILTER <namespace.msgname>
 kamanja list adaptermessagebindings SERIALIZERFILTER <namespace.serializername>
 kamanja get typebyschemaid SCHEMAID <schemaid>
 kamanja get typebyelementid ELEMENTID <elementid>
-XVI. General operations
+XIII. General operations
 kamanja --version

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/StartMetadataAPI.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/StartMetadataAPI.scala
@@ -682,7 +682,7 @@ object StartMetadataAPI {
     response
   }
 
-  /**
+  /** NOT USED
    * AltRoute is invoked only if the 'Action.withName(action.trim)' method fails to discern the appropriate
    * MetadataAPI method to invoke.  The command argument array is reconsidered with the AlternateCmdParser
    * If it produces valid command arguments (a command name and Map[String,String] of arg name/values) **and**
@@ -695,7 +695,7 @@ object StartMetadataAPI {
    *         complaint is returned to the caller.
    *
    */
-  def AltRoute(origArgs: Array[String]): String = {
+ /* def AltRoute(origArgs: Array[String]): String = {
 
     /** trim off the config argument and if debugging the "debug" argument as well */
     val argsSansConfig: Array[String] = if (origArgs != null && origArgs.size > 0 && origArgs(0).toLowerCase == "debug") {
@@ -817,5 +817,5 @@ object StartMetadataAPI {
     }
 
     response
-  }
+  } */
 }

--- a/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/AlternateCmdParser.scala
+++ b/trunk/MetadataAPI/src/main/scala/com/ligadata/MetadataAPI/Utility/AlternateCmdParser.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/*
 package com.ligadata.MetadataAPI.Utility
 
 import scala.util.matching.Regex
@@ -166,4 +166,4 @@ object AlternateCmdParser extends JavaTokenParsers {
     }
 
 }
-
+*/


### PR DESCRIPTION
Remove Alternate command parser usage from Metadata API. AlternateCmdParser.scala commented out. Also, commented the method def AltRoute(origArgs: Array[String]) as it is not being used in the StartMetadataAPI.scala