### PR TITLE
Address quava library conflicts discovered during 1.6.0 upgrade testing

### DIFF
--- a/trunk/KamanjaInternalDeps/build.sbt
+++ b/trunk/KamanjaInternalDeps/build.sbt
@@ -17,9 +17,7 @@ assemblyMergeStrategy in assembly := {
 
 }
 
-val excludes = Set("commons-beanutils-1.7.0.jar", "google-collections-1.0.jar", "commons-collections4-4.0.jar", "log4j-1.2.17.jar", "log4j-1.2.16.jar", "commons-collections-4-4.0.jar", "scalatest_2.11-2.2.0.jar"
-    , "scala-reflect-2.11.0.jar", "akka-actor_2.11-2.3.2.jar", "scala-reflect-2.11.2.jar", "scalatest_2.11-2.2.4.jar", "joda-time-2.9.1-javadoc.jar", "voldemort-0.96.jar", "scala-compiler-2.11.0.jar", "guava-16.0.1.jar"
-    , "minlog-1.2.jar")
+val excludes = Set("commons-beanutils-1.7.0.jar", "google-collections-1.0.jar", "commons-collections4-4.0.jar", "log4j-1.2.17.jar", "log4j-1.2.16.jar", "commons-collections-4-4.0.jar", "scalatest_2.11-2.2.0.jar", "scala-reflect-2.11.0.jar", "akka-actor_2.11-2.3.2.jar", "scala-reflect-2.11.2.jar", "scalatest_2.11-2.2.4.jar", "joda-time-2.9.1-javadoc.jar", "voldemort-0.96.jar", "scala-compiler-2.11.0.jar", "guava-16.0.1.jar", "guava-14.0.1.jar", "guava-r03.jar","minlog-1.2.jar")
 
 
 excludedJars in assembly <<= (fullClasspath in assembly) map { cp =>

--- a/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterCfgMetadataAPIConfig.properties
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterCfgMetadataAPIConfig.properties
@@ -1,5 +1,5 @@
 NODEID={NodeId}
-MetadataDataStore={"StoreType": "hbase","SchemaName": "kamanja","Location": "localhost", "authentication":"kerberos","regionserver_principal":"hbase/_HOST@INTRANET.LIGADATA.COM","master_principal":"hbase/_HOST@INTRANET.LIGADATA.COM","principal":"ligadata@INTRANET.LIGADATA.COM","keytab":"{InstallDirectory}/config/ligadata.keytab"}
+MetadataDataStore={"StoreType": "h2db","connectionMode": "embedded","SchemaName": "kamanja","Location": "{InstallDirectory}/storage","portnumber": "9100","user": "test","password": "test"}
 ROOT_DIR={InstallDirectory}
 GIT_ROOT={InstallDirectory}
 JAR_TARGET_DIR={InstallDirectory}/lib/application

--- a/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v10.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v10.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v8.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v8.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v9.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.10/ClusterConfig_kafka_v9.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.10/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.10/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterCfgMetadataAPIConfig.properties
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterCfgMetadataAPIConfig.properties
@@ -1,5 +1,5 @@
 NODEID={NodeId}
-MetadataDataStore={"StoreType": "hbase","SchemaName": "kamanja","Location": "localhost", "authentication":"kerberos","regionserver_principal":"hbase/_HOST@INTRANET.LIGADATA.COM","master_principal":"hbase/_HOST@INTRANET.LIGADATA.COM","principal":"ligadata@INTRANET.LIGADATA.COM","keytab":"{InstallDirectory}/config/ligadata.keytab"}
+MetadataDataStore={"StoreType": "h2db","connectionMode": "embedded","SchemaName": "kamanja","Location": "{InstallDirectory}/storage","portnumber": "9100","user": "test","password": "test"}
 ROOT_DIR={InstallDirectory}
 GIT_ROOT={InstallDirectory}
 JAR_TARGET_DIR={InstallDirectory}/lib/application

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v10.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v10.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v8.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v8.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v9.json
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/ClusterConfig_kafka_v9.json
@@ -6,7 +6,7 @@
         "StoreType": "h2db",
         "connectionMode": "embedded",
         "SchemaName": "kamanja",
-        "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/syscatalog",
+        "Location": "{InstallDirectory}/storage/syscatalog",
         "portnumber": "9100",
         "user": "test",
         "password": "test"
@@ -19,7 +19,7 @@
             "StoreType": "h2db",
             "connectionMode": "embedded",
             "SchemaName": "testdata",
-            "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_default",
+            "Location": "{InstallDirectory}/storage/tenant1_default",
             "portnumber": "9100",
             "user": "test",
             "password": "test"
@@ -56,8 +56,8 @@
           "NodePort": 6541,
           "NodeIpAddr": "localhost",
           "JarPaths": [
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system",
-            "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/application"
+            "{InstallDirectory}/lib/system",
+            "{InstallDirectory}/lib/application"
           ],
           "Scala_home": "/home/vmandava/scala-2.11.7",
           "Java_home": "/home/vmandava/jdk1.8.0_05",
@@ -65,7 +65,7 @@
             "RestAPI",
             "ProcessingEngine"
           ],
-          "Classpath": ".:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:/media/home2/installKamanja160/Kamanja-1.6.0_2.11/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
+          "Classpath": ".:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:{InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar"
         }
       ],
       "Adapters": [
@@ -76,7 +76,7 @@
           "StoreType": "h2db",
           "connectionMode": "embedded",
           "SchemaName": "testdata",
-          "Location": "/media/home2/installKamanja160/Kamanja-1.6.0_2.11/storage/tenant1_storage_1",
+          "Location": "{InstallDirectory}/storage/tenant1_storage_1",
           "portnumber": "9100",
           "user": "test",
           "password": "test"

--- a/trunk/Storage/SqlServer/src/test/scala/DropAllTables.scala
+++ b/trunk/Storage/SqlServer/src/test/scala/DropAllTables.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 ligaDATA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ligadata.automation.unittests.sqlserveradapter
+
+import org.scalatest._
+import Matchers._
+
+import com.ligadata.Utils._
+import util.control.Breaks._
+import scala.io._
+import java.util.{Date,Calendar,TimeZone}
+import java.text.{SimpleDateFormat}
+import java.io._
+
+import sys.process._
+import org.apache.logging.log4j._
+
+import com.ligadata.keyvaluestore._
+import com.ligadata.KvBase._
+import com.ligadata.StorageBase._
+import com.ligadata.Serialize._
+import com.ligadata.Utils.Utils._
+import com.ligadata.Utils.{ KamanjaClassLoader, KamanjaLoaderInfo }
+import com.ligadata.StorageBase.StorageAdapterFactory
+import com.ligadata.keyvaluestore.SqlServerAdapter
+
+import com.ligadata.Exceptions._
+
+class DropAllTables extends FunSpec with BeforeAndAfter with BeforeAndAfterAll with GivenWhenThen {
+  var res : String = null;
+  var statusCode: Int = -1;
+  var adapter:DataStore = null
+  var serializer:Serializer = null
+
+  private val loggerName = this.getClass.getName
+  private val logger = LogManager.getLogger(loggerName)
+
+  val dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+  val dateFormat1 = new SimpleDateFormat("yyyy/MM/dd")
+  // set the timezone to UTC for all time values
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+  var containerName = ""
+  private val kvManagerLoader = new KamanjaLoaderInfo
+  private val maxConnectionAttempts = 10
+
+  serializer = SerializerManager.GetSerializer("kryo")
+  logger.info("Initialize SqlServerAdapter")
+  val dataStoreInfo = """{"StoreType": "sqlserver","hostname": "192.168.56.1","instancename":"KAMANJA","portnumber":"1433","database": "bofa","user":"bofauser","SchemaName":"bofauser","password":"bofauser","jarpaths":"/media/home2/jdbc","jdbcJar":"sqljdbc4-2.0.jar","clusteredIndex":"YES","autoCreateTables":"YES"}"""
+
+  private def CreateAdapter: DataStore = {
+    var connectionAttempts = 0
+    while (connectionAttempts < maxConnectionAttempts) {
+      try {
+        adapter = SqlServerAdapter.CreateStorageAdapter(kvManagerLoader, dataStoreInfo, null, null)
+        return adapter
+      } catch {
+        case e: Exception => {
+          logger.error("will retry after one minute ...", e)
+          Thread.sleep(60 * 1000L)
+          connectionAttempts = connectionAttempts + 1
+        }
+      }
+    }
+    return null;
+  }
+
+  override def beforeAll = {
+    logger.info("starting...");
+    CreateAdapter
+  }
+
+  def deleteFile(path:File):Unit = {
+    if(path.exists()){
+      if (path.isDirectory){
+	for(f <- path.listFiles) {
+          deleteFile(f)
+	}
+      }
+      path.delete()
+    }
+  }
+
+  describe("Drop All User Tables ") {
+    it("drop sqlserver tables"){
+      logger.info("fetch all tables...")
+      val tblList = adapter.getAllTables
+      logger.info("drop all tables...")
+      adapter.dropTables(tblList)
+    }
+  }
+
+  override def afterAll = {
+    var logFile = new java.io.File("logs")
+    if( logFile != null ){
+      deleteFile(logFile)
+    }
+  }
+}


### PR DESCRIPTION
Earlier I created a branch upgradeTo160 to address this issue. However, during retest with latest 160 code, I encountered some issues with conflicting guava libraries in 160 fat jars. I created a new branch
Update160Issues( meant to call it Upgrade160Issues)  that includes all of the earlier changes.

Please use this branch to test 1.5.x to 1.6.x upgrade or 1.6.x to 1.6.x upgrade( we don't have 1.6.1 yet, so 1.6.0 to 1.6.1 can't be tested yet)
