### PR TITLE
 MetadataManager, Webservice and StartEngine accept JVM options

### DIFF
--- a/trunk/MetadataAPI/src/main/resources/HelpMenu.txt
+++ b/trunk/MetadataAPI/src/main/resources/HelpMenu.txt
@@ -42,14 +42,14 @@ kamanja dump all clusters
 kamanja dump all cluster cfgs
 kamanja dump all adapters
 VII. Kamanja engine operations
-kamanja start
-kamanja start -v (for verbose)
+kamanja start jvmoptions(optional) Properties/PropertiesFile(optional)
+kamanja start -v (for verbose) jvmoptions(optional) Properties/PropertiesFile(optional)
 VIII. Topic operations
 kamanja watch status queue
 kamanja push data
 kamanja create queues
 IX. Web service
-kamanja start webservice
+kamanja start jvmoptions(optional) webservice
 X. Adapter Message Bindings
 kamanja add adaptermessagebinding FROMFILE input
 kamanja add adaptermessagebinding FROMSTRING input

--- a/trunk/MetadataAPI/src/main/resources/MetadataAPIConfig.properties
+++ b/trunk/MetadataAPI/src/main/resources/MetadataAPIConfig.properties
@@ -17,3 +17,4 @@ SERVICE_PORT=8081
 SECURITY_IMPL_JAR=/tmp/InstallDirectory/lib/system/simpleapacheshiroadapter_2.11-1.0.jar
 SECURITY_IMPL_CLASS=com.ligadata.Security.SimpleApacheShiroAdapter
 DO_AUTH=NO
+JVMOPTIONS=-Xms4g -Xmx4g

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.10/config/MetadataAPIConfig_Template.properties
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.10/config/MetadataAPIConfig_Template.properties
@@ -31,3 +31,4 @@ AUDIT_IMPL_CLASS=com.ligadata.audit.adapters.AuditCassandraAdapter
 DO_AUDIT=NO
 DO_AUTH=NO
 SSL_CERTIFICATE={InstallDirectory}/config/keystore.jks
+JVMOPTIONS=-Xms4g -Xmx4g

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.10/script/StartEngine_Template.sh
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.10/script/StartEngine_Template.sh
@@ -1,8 +1,36 @@
 #!/bin/sh
 KAMANJA_HOME={InstallDirectory}
-PROP_FILE=$1
-# Start the engine with hashdb backed metadata configuration.  The zookeeper and your queue software should be running
-# Start the engine with hashdb backed metadata configuration.  The zookeeper and your queue software should be running
+
+KAMANJA_HOME={InstallDirectory}
+for var in "$@"
+do
+    echo "$var"
+    if [ $var == "debug" ]; then
+         DEBUG=$var
+    elif [[ $var == *.properties ]]; then
+        PROP_FILE=$var
+    elif [[ $var == *.properties ]]; then
+        PROP_FILE=$var
+    else
+        JVMOPTIONS=$var
+    fi
+done
+
+if [ -z $PROP_FILE ]; then
+   PROP_FILE={InstallDirectory}/config/Engine1Config.properties
+    echo "Using the default properties file"
+fi
+
+
+if [ -z $JVMOPTIONS ]; then
+    echo "Using default JVM options Engine1Config.properties"
+    JVMOPTIONS=`grep -i "JVM" $PROP_FILE | cut -d"=" -f2`
+fi
+
+echo "PROP_FILE: $PROP_FILE"
+echo "DEBUG: $DEBUG"
+echo "JVMOPTIONS: $JVMOPTIONS"
+
 ipport="8998"
 
 #-Djava.security.auth.login.config=/tmp/kerberos/jaas-client.conf
@@ -18,8 +46,8 @@ fi
 
 currentKamanjaVersion=1.6.0
 
-if [ "$1" != "debug" ]; then
-    java  $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.10-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
+if [ "$DEBUG" != "debug" ]; then
+    java $JVMOPTIONS  $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.10-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
 else
-	java  $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.10-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
+	java $JVMOPTIONS  $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.10-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.10-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
 fi

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.10/script/StartEngine_Template.sh
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.10/script/StartEngine_Template.sh
@@ -4,7 +4,6 @@ KAMANJA_HOME={InstallDirectory}
 KAMANJA_HOME={InstallDirectory}
 for var in "$@"
 do
-    echo "$var"
     if [ $var == "debug" ]; then
          DEBUG=$var
     elif [[ $var == *.properties ]]; then

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.11/config/EngineConfig_Template.properties
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.11/config/EngineConfig_Template.properties
@@ -1,7 +1,7 @@
 #########################################
 # Node Information
 nodeId=1
-
+JVM=-Xms4g -Xmx4g
 #########################################
 #MetadataStore information
 MetadataDataStore={"StoreType": "h2db","connectionMode": "embedded","SchemaName": "kamanja","Location": "{InstallDirectory}/storage","portnumber": "9100","user": "test","password": "test"}

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.11/config/MetadataAPIConfig_Template.properties
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.11/config/MetadataAPIConfig_Template.properties
@@ -31,3 +31,4 @@ AUDIT_IMPL_CLASS=com.ligadata.audit.adapters.AuditCassandraAdapter
 DO_AUDIT=NO
 DO_AUTH=NO
 SSL_CERTIFICATE={InstallDirectory}/config/keystore.jks
+JVMOPTIONS=-Xms4g -Xmx4g

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.11/script/StartEngine_Template.sh
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.11/script/StartEngine_Template.sh
@@ -3,7 +3,6 @@ KAMANJA_HOME={InstallDirectory}
 DEBUG=false
 for var in "$@"
 do
-    echo "$var"
     if [ $var == "debug" ]; then
          DEBUG=true
     elif [[ $var == *.properties ]]; then

--- a/trunk/SampleApplication/EasyInstall/template/scala-2.11/script/StartEngine_Template.sh
+++ b/trunk/SampleApplication/EasyInstall/template/scala-2.11/script/StartEngine_Template.sh
@@ -1,10 +1,34 @@
 #!/bin/sh
 KAMANJA_HOME={InstallDirectory}
-PROP_FILE=$1
-if [ -z $1 ]; then
+DEBUG=false
+for var in "$@"
+do
+    echo "$var"
+    if [ $var == "debug" ]; then
+         DEBUG=true
+    elif [[ $var == *.properties ]]; then
+        PROP_FILE=$var
+    elif [[ $var == *.properties ]]; then
+        PROP_FILE=$var
+    else
+        JVMOPTIONS=$var
+    fi
+done
+
+if [ -z $PROP_FILE ]; then
    PROP_FILE={InstallDirectory}/config/Engine1Config.properties
-   echo "Using the default file, {InstallDirectory}/config/Engine1Config.properties "
+   echo "Using the default properties file"
 fi
+
+if [ -z $JVMOPTIONS ]; then
+    echo "Using default JVM options Engine1Config.properties"
+    JVMOPTIONS=`grep -i "JVM" $PROP_FILE | cut -d"=" -f2`
+fi
+
+
+echo "PROP_FILE: $PROP_FILE"
+echo "DEBUG: $DEBUG"
+echo "JVMOPTIONS: $JVMOPTIONS"
 
 # Start the engine with hashdb backed metadata configuration.  The zookeeper and your queue software should be running
 ipport="8998"
@@ -22,8 +46,8 @@ fi
 
 currentKamanjaVersion=1.6.0
 
-if [ "$1" != "debug" ]; then
-	java $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.11-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
+if [ "$DEBUG" != true ]; then
+	java $JVMOPTIONS $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.11-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
 else
-	java $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.11-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
+	java $JVMOPTIONS $JAAS_CONFIG_OPT $KERBEROS_CONFIG_OPT -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:{InstallDirectory}/config/log4j2.xml -cp {InstallDirectory}/lib/system/ExtDependencyLibs2_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/ExtDependencyLibs_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/KamanjaInternalDeps_2.11-${currentKamanjaVersion}.jar:{InstallDirectory}/lib/system/kamanjamanager_2.11-${currentKamanjaVersion}.jar com.ligadata.KamanjaManager.KamanjaManager --config $PROP_FILE
 fi

--- a/trunk/Utils/Script/scala-2.11/kamanja
+++ b/trunk/Utils/Script/scala-2.11/kamanja
@@ -76,7 +76,7 @@ if [ "${array[0] }" = "edit" ]; then
   fi
   done < ~/MetadataAPIConfig.properties
   echo "${array[2]}=${array[3]}" >> ~/MetadataAPIConfig.temp
-  mv ~/MetadataAPIConfig.temp ~/MetadataAPIConfig.prope rties
+  mv ~/MetadataAPIConfig.temp ~/MetadataAPIConfig.properties
   echo "MetadataAPIConfig.properties update complete!"
   exit 0
 fi

--- a/trunk/Utils/Script/scala-2.11/kamanja
+++ b/trunk/Utils/Script/scala-2.11/kamanja
@@ -76,14 +76,20 @@ if [ "${array[0] }" = "edit" ]; then
   fi
   done < ~/MetadataAPIConfig.properties
   echo "${array[2]}=${array[3]}" >> ~/MetadataAPIConfig.temp
-  mv ~/MetadataAPIConfig.temp ~/MetadataAPIConfig.properties
+  mv ~/MetadataAPIConfig.temp ~/MetadataAPIConfig.prope rties
   echo "MetadataAPIConfig.properties update complete!"
   exit 0
 fi
 
+grep -i "jvm" MetadataAPIConfig.properties >> /dev/null
+ISJVM=$?
+if [ $ISJVM = 0 ]; then
+  JVMOPTIONS=`grep -i "jvm" MetadataAPIConfig.properties | cut -d"=" -f2`
+fi
+
 if [ "$INPUT" = "start webservice" ]; then
   echo "Starting web service . . . ."
-  java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapiservice_2.11-1.6.0.jar com.ligadata.metadataapiservice.APIService
+  java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapiservice_2.11-1.6.0.jar com.ligadata.metadataapiservice.APIService
 
 elif [ "$IS_START" == "start" ] && [ "$IS_VERBOSE" == true ]; then
    $KAMANJA_HOME/bin/StartEngine.sh "$3"
@@ -165,9 +171,9 @@ else
     if [ -n "$attachDebugger" ]; then
         ipport="8998"
 
-        java -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
+        java $JVMOPTIONS -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
     else
-        java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
+        java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
 
     fi
 fi

--- a/trunk/Utils/Script/scala-2.11/kamanja
+++ b/trunk/Utils/Script/scala-2.11/kamanja
@@ -89,7 +89,7 @@ fi
 
 if [ "$INPUT" = "start webservice" ]; then
   echo "Starting web service . . . ."
-  java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapiservice_2.11-1.6.0.jar com.ligadata.metadataapiservice.APIService
+  java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml $JVMOPTIONS -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapiservice_2.11-1.6.0.jar com.ligadata.metadataapiservice.APIService
 
 elif [ "$IS_START" == "start" ] && [ "$IS_VERBOSE" == true ]; then
    $KAMANJA_HOME/bin/StartEngine.sh "$3"
@@ -171,9 +171,9 @@ else
     if [ -n "$attachDebugger" ]; then
         ipport="8998"
 
-        java $JVMOPTIONS -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
+        java -Xdebug -Xrunjdwp:transport=dt_socket,address="$ipport",server=y -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml $JVMOPTIONS -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
     else
-        java $JVMOPTIONS -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
+        java -Dlog4j.configurationFile=file:$KAMANJA_HOME/config/log4j2.xml $JVMOPTIONS -cp $KAMANJA_HOME/lib/system/ExtDependencyLibs2_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/ExtDependencyLibs_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/KamanjaInternalDeps_2.11-1.6.0.jar:$KAMANJA_HOME/lib/system/metadataapi_2.11-1.6.0.jar com.ligadata.MetadataAPI.StartMetadataAPI "$@"
 
     fi
 fi

--- a/trunk/Utils/Script/scala-2.11/kamanja
+++ b/trunk/Utils/Script/scala-2.11/kamanja
@@ -81,10 +81,10 @@ if [ "${array[0] }" = "edit" ]; then
   exit 0
 fi
 
-grep -i "jvm" MetadataAPIConfig.properties >> /dev/null
+grep -i "jvm" $KAMANJA_HOME/config/MetadataAPIConfig.properties >> /dev/null
 ISJVM=$?
 if [ $ISJVM = 0 ]; then
-  JVMOPTIONS=`grep -i "jvm" MetadataAPIConfig.properties | cut -d"=" -f2`
+  JVMOPTIONS=`grep -i "jvm" $KAMANJA_HOME/config/MetadataAPIConfig.properties | cut -d"=" -f2`
 fi
 
 if [ "$INPUT" = "start webservice" ]; then


### PR DESCRIPTION
StartEngine now accepts JVMoptions, properties and debug as a command line argument. It also accepts JVM options through Engine1Config.properties as default. Similarly, MetadataManager and web service, accept JVMOptions from MetadataAPI.properties.
