### PR TITLE
1.5.3 phoenix flr 304

### DIFF
--- a/trunk/EnvContexts/SimpleEnvContextImpl/src/main/scala/com/ligadata/SimpleEnvContextImpl/SimpleEnvContextImpl.scala
+++ b/trunk/EnvContexts/SimpleEnvContextImpl/src/main/scala/com/ligadata/SimpleEnvContextImpl/SimpleEnvContextImpl.scala
@@ -51,6 +51,7 @@ import scala.collection.JavaConverters._
 import akka.actor._
 import com.typesafe.config.ConfigFactory
 import akka.routing.RoundRobinPool
+import java.util.UUID
 
 trait LogTrait {
   val loggerName = this.getClass.getName()
@@ -172,7 +173,9 @@ object SimpleEnvContextImpl extends EnvContext with LogTrait {
   private val STORAGE_READ_COUNT = "READS"
   private val STORAGE_WRITE_COUNT = "WRITES"
 
-  private var _nodeId: String = _
+  private var _nodeId: String = ""
+  private val _nodeUUID = UUID.randomUUID().toString();
+  private var _nodeIdAndUUID = createNodeIdAndUUID
   private var _clusterId: String = _
   private val _setZk_reent_lock = new ReentrantReadWriteLock(true)
   private var _setZkData: CuratorFramework = _
@@ -2247,7 +2250,7 @@ object SimpleEnvContextImpl extends EnvContext with LogTrait {
     try {
       if (_zkLeaderLatch == null) {
         logger.warn("DistributionCheck:registerNodesChangeNotification. Registering as new listener and starting leader")
-        _zkLeaderLatch = new ZkLeaderLatch(_zkConnectString, _zkleaderNodePath, _nodeId, EnvCtxtEventChangeCallback, _zkSessionTimeoutMs, _zkConnectionTimeoutMs)
+        _zkLeaderLatch = new ZkLeaderLatch(_zkConnectString, _zkleaderNodePath, _nodeIdAndUUID, EnvCtxtEventChangeCallback, _zkSessionTimeoutMs, _zkConnectionTimeoutMs)
         _zkLeaderListeners += LeaderListenerCallback(EventChangeCallback)
         _zkLeaderLatch.SelectLeader
       } else {
@@ -2274,9 +2277,18 @@ object SimpleEnvContextImpl extends EnvContext with LogTrait {
 
   override def getClusterId(): String = _clusterId
 
+  private def createNodeIdAndUUID: String = {
+    """{"NodeId":"%s","UUID":"%s"}""".format(_nodeId, _nodeUUID)
+  }
+
+  override def getNodeIdAndUUID(): String = _nodeIdAndUUID
+
+  override def getNodeUUID(): String = _nodeUUID
+
   override def setNodeInfo(nodeId: String, clusterId: String): Unit = {
     _nodeId = nodeId
     _clusterId = clusterId
+    _nodeIdAndUUID = createNodeIdAndUUID
   }
 
   // This post the message into where ever these messages are associated immediately

--- a/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
+++ b/trunk/KamanjaBase/src/main/scala/com/ligadata/KamanjaBase/ModelBase.scala
@@ -468,6 +468,8 @@ trait EnvContext /* extends Monitorable */  {
 
   def getNodeId(): String
   def getClusterId(): String
+  def getNodeIdAndUUID(): String
+  def getNodeUUID(): String
 
   def setNodeInfo(nodeId: String, clusterId: String): Unit
 

--- a/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaLeader.scala
+++ b/trunk/KamanjaManager/src/main/scala/com/ligadata/KamanjaManager/KamanjaLeader.scala
@@ -805,7 +805,7 @@ object KamanjaLeader {
 //              envCtxt.clearIntermediateResults
 
               // Set STOPPED action in adaptersStatusPath + "/" + nodeId path
-              val adaptrStatusPathForNode = adaptersStatusPath + "/" + nodeId
+              val adaptrStatusPathForNode = adaptersStatusPath + "/" + envCtxt.getNodeIdAndUUID()
               val act = ("action" -> "stopped")
               val sendJson = compact(render(act))
               LOG.warn("New Action Stopped set to " + adaptrStatusPathForNode)
@@ -847,7 +847,7 @@ object KamanjaLeader {
             }
           }
 
-          val adaptrStatusPathForNode = adaptersStatusPath + "/" + nodeId
+          val adaptrStatusPathForNode = adaptersStatusPath + "/" + envCtxt.getNodeIdAndUUID()
           var sentDistributed = false
           if (distributed) {
             try {
@@ -1302,7 +1302,7 @@ object KamanjaLeader {
 
     if (zkConnectString != null && zkConnectString.isEmpty() == false && engineLeaderZkNodePath != null && engineLeaderZkNodePath.isEmpty() == false && engineDistributionZkNodePath != null && engineDistributionZkNodePath.isEmpty() == false && dataChangeZkNodePath != null && dataChangeZkNodePath.isEmpty() == false) {
       try {
-        val adaptrStatusPathForNode = adaptersStatusPath + "/" + nodeId
+        val adaptrStatusPathForNode = adaptersStatusPath + "/" + envCtxt.getNodeIdAndUUID()
         LOG.info("ZK Connecting. adaptrStatusPathForNode:%s, zkConnectString:%s, engineLeaderZkNodePath:%s, engineDistributionZkNodePath:%s, dataChangeZkNodePath:%s".format(adaptrStatusPathForNode, zkConnectString, engineLeaderZkNodePath, engineDistributionZkNodePath, dataChangeZkNodePath))
         CreateClient.CreateNodeIfNotExists(zkConnectString, engineDistributionZkNodePath) // Creating 
         CreateClient.CreateNodeIfNotExists(zkConnectString, adaptrStatusPathForNode) // Creating path for Adapter Statues
@@ -1436,25 +1436,6 @@ object KamanjaLeader {
                     } else {
                       updatePartsCntr += 1
                     }
-/*
-                    if (wait4ValidateCheck > 0) {
-                      // Get Partitions keys and values for every M secs
-                      if (getValidateAdapCntr >= wait4ValidateCheck) { // for every waitForValidateCheck secs
-                        // Persists the previous ones if we have any
-                        if (validateUniqVals != null && validateUniqVals.size > 0) {
-                          envCtxt.PersistValidateAdapterInformation(validateUniqVals.map(kv => (kv._1.Serialize, kv._2.Serialize)))
-                        }
-                        // Get the latest ones
-//                        validateUniqVals = GetEndPartitionsValuesForValidateAdapters
-                        getValidateAdapCntr = 0
-                        wait4ValidateCheck = 60 // Next time onwards it is 60 secs
-                      } else {
-                        getValidateAdapCntr += 1
-                      }
-                    } else {
-                      getValidateAdapCntr = 0
-                    }
-*/
                   }
                 } else {
                   wait4ValidateCheck = 0 // Not leader node, don't check for it until we set it in redistribute


### PR DESCRIPTION
Making sure each upcoming node has different nodeid in work load distribution.

@ligadata-william , if two instances of same node comes up also it should be able distribute the work load between them without any issue instead of reprocessing the same partitions on both instances.
