### PR TITLE
Cluster Start & Stop scripts changes

### DIFF
--- a/trunk/SampleApplication/ClusterInstall/scala-2.10/StartKamanjaCluster.sh
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.10/StartKamanjaCluster.sh
@@ -160,7 +160,7 @@ while read LINE; do
 		if [ ! -d "$installDir/run" ]; then
 			mkdir "$installDir/run"
 		fi
-			ps aux | egrep "KamanjaManager|MetadataAPIService" | grep -v "grep" | tr -s " " | cut -d " " -f2 | tr "\\n" "," | sed "s/,$//"   > "$installDir/run/$pidfile"
+			ps aux | egrep "KamanjaManager|MetadataAPIService" | grep -v "grep" | grep "$installDir" | tr -s " " | cut -d " " -f2 | tr "\\n" "," | sed "s/,$//"   > "$installDir/run/$pidfile"
 #		sleep 5
 EOF
 

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/StartKamanjaCluster.sh
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/StartKamanjaCluster.sh
@@ -159,7 +159,7 @@ while read LINE; do
 		if [ ! -d "$installDir/run" ]; then
 			mkdir "$installDir/run"
 		fi
-			ps aux | egrep "KamanjaManager|MetadataAPIService" | grep -v "grep" | tr -s " " | cut -d " " -f2 | tr "\\n" "," | sed "s/,$//"   > "$installDir/run/$pidfile"
+			ps aux | egrep "KamanjaManager|MetadataAPIService" | grep -v "grep" | grep "$installDir" | tr -s " " | cut -d " " -f2 | tr "\\n" "," | sed "s/,$//"   > "$installDir/run/$pidfile"
 #		sleep 5
 EOF
 

--- a/trunk/SampleApplication/ClusterInstall/scala-2.11/StopKamanjaCluster.sh
+++ b/trunk/SampleApplication/ClusterInstall/scala-2.11/StopKamanjaCluster.sh
@@ -11,6 +11,7 @@ Usage()
     echo "      StopKamanjaCluster.sh --ClusterId <cluster name identifer> "
     echo "                           --MetadataAPIConfig  <metadataAPICfgPath>  "
     echo "                           [--NodeIds  <nodeIds>] "
+    echo "                           [--JstackLocation <JstackPath>] "
     echo 
     echo "  NOTES: Stop the cluster specified by the cluster identifier parameter.  Use the metadata api configuration to locate"
     echo "         the appropriate metadata store.  "
@@ -21,7 +22,7 @@ Usage()
 scalaVersion="2.11"
 name1=$1
 currentKamanjaVersion=1.5.3
-
+ScriptStartTime=`date +%Y%m%d%H%M%S`
 
 if [[ "$#" -eq 4 || "$#" -eq 6 ]]; then
     echo
@@ -43,6 +44,7 @@ fi
 metadataAPIConfig=""
 clusterId=""
 nodeIds=""
+jstackLocation=""
 valid_nodeIds=();
 
 while [ "$1" != "" ]; do
@@ -56,6 +58,9 @@ while [ "$1" != "" ]; do
                                 ;;
         --NodeIds )             shift
                                 nodeIds=$1
+                                ;;
+        --JstackLocation )      shift
+                                jstackLocation=$1
                                 ;;
         * )                     echo "Problem: Argument $1 is invalid named parameter."
                                 Usage
@@ -142,7 +147,19 @@ while read LINE; do
 
     if [ ! -z "$pidvals" ]; then
        if [ -n "$pidvals" ]; then
-            echo "Killing Pid(s):$pidvals on $machine"
+           if [ "$jstackLocation" != "" ]; then
+              echo "About to jstack for PID(s):$pidvals on node $machine at $jstackLocation"
+              for pid in ${pidvals// / } ; do 
+                 if [ "$pid" != "" ]; then
+                    file="$jstackLocation/Kamanja_PID_${pid}_${ScriptStartTime}.jstack"
+                    echo "Producing jstack information for PID:$pid on node $machine to $file"
+                    ssh -o StrictHostKeyChecking=no -T $machine  <<-EOF
+                       jstack $pid > $file
+EOF
+                 fi
+              done
+           fi
+           echo "Killing Pid(s):$pidvals on $machine"
            # FIXME: We can check whether we really have pidvals or not and do ssh
            ssh -o StrictHostKeyChecking=no -T $machine  <<-EOF
               kill -15 $pidvals


### PR DESCRIPTION

1. Changed StartKamanjaCluster.sh to make sure we collect pids for the services started from the $installDir. This enable us to have multiple installations on same node.

2. Added option JstackLocation to StopKamanjaCluster.sh to produce jstack while stopping the nodes. JstackLocation is the location where we need to produce the jstacks on each local node.

