### PR TITLE
1.5.3 phoenix avro support

### DIFF
--- a/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/AdaptersConfiguration/SmartFileProducerConfiguration.scala
+++ b/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/AdaptersConfiguration/SmartFileProducerConfiguration.scala
@@ -74,6 +74,16 @@ class SmartFileProducerConfiguration extends AdapterConfiguration {
       }
     }
 
+  def isAvro = (compressionString != null && compressionString.toLowerCase.startsWith("avro"))
+  def avroCodec: String = {
+    if (! isAvro) {
+      ""
+    } else {
+      val tokens = compressionString.split("/")
+      if(tokens.length == 1)  "" else tokens(1).toLowerCase
+    }
+  }
+
 }
 
 

--- a/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/SmartFileProducer.scala
+++ b/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/SmartFileProducer.scala
@@ -60,11 +60,13 @@ object SmartFileProducer extends OutputAdapterFactory {
 
 object PartitionFileFactory {
   def createPartitionFile(fc: SmartFileProducerConfiguration, key: String, avroSchema: Option[String], ignoreFields: Array[String]): PartitionFile = {
-    if (fc.isParquet) new ParquetPartitionFile(fc, key, avroSchema.get, ignoreFields)
-    else new StreamPartitionFile(fc, key)
-
+    if (fc.isParquet) {
+      new ParquetPartitionFile(fc, key, avroSchema.get, ignoreFields)
+    }
+    else {
+      new StreamPartitionFile(fc, key, avroSchema.get)
+    }
   }
-
 }
 
 object SendStatus {
@@ -465,7 +467,7 @@ class SmartFileProducer(val inputConfig: AdapterConfiguration, val nodeContext: 
     LOG.info(">>>>>>>>> using parquet with compression: " + parquetCompression)
   else LOG.info(">>>>>>>>> compression: " + fc.compressionString)
 
-  val defaultExtension = if (isParquet) "" else fc.compressionString
+  val defaultExtension = if (isParquet || fc.isAvro) "" else fc.compressionString
 
   val compress = (fc.compressionString != null && !isParquet)
   if (compress) {
@@ -683,7 +685,9 @@ class SmartFileProducer(val inputConfig: AdapterConfiguration, val nodeContext: 
           // need to check again
           val dt = if (nextRolloverTime > 0) nextRolloverTime - (fc.rolloverInterval * 60 * 1000) else System.currentTimeMillis
           val ts = new java.text.SimpleDateFormat("yyyyMMdd'T'HHmm").format(new java.util.Date(dt))
-          val initialFileName = "%s/%s/%s%s-%d-%s.dat%s".format(fc.uri, path, fc.fileNamePrefix, nodeId, bucket, ts, extensions.getOrElse(defaultExtension, ""))
+          val baseFileExt = if (fc.isAvro) ".avro" else ".dat"
+          val finalExtn = "%s%s".format(baseFileExt, extensions.getOrElse(defaultExtension, ""))
+          val initialFileName = "%s/%s/%s%s-%d-%s%s".format(fc.uri, path, fc.fileNamePrefix, nodeId, bucket, ts, finalExtn)
           val fileName =
             if (isParquet) {
               //cannot use already existing parquet file
@@ -696,12 +700,20 @@ class SmartFileProducer(val inputConfig: AdapterConfiguration, val nodeContext: 
                 val newDt = System.currentTimeMillis
                 nextRolloverTime = newDt + (fc.rolloverInterval * 60 * 1000)
                 val newTs = new java.text.SimpleDateFormat("yyyyMMdd'T'HHmm").format(new java.util.Date(newDt))
-                "%s/%s/%s%s-%d-%s.dat%s".format(fc.uri, path, fc.fileNamePrefix, nodeId, bucket, newTs, extensions.getOrElse(defaultExtension, ""))
+                "%s/%s/%s%s-%d-%s%s".format(fc.uri, path, fc.fileNamePrefix, nodeId, bucket, newTs, finalExtn)
+              } else initialFileName
+            } else if (fc.isAvro) {
+              // BUGBUG:: Does not want to append the data for the same file for now. Later we can use appendTo while creating the file
+              val extLen = baseFileExt.length
+              var flPath = initialFileName
+              while (isFileExists(fc, flPath)) {
+                val flWithoutExtn = flPath.substring(0, flPath.length - extLen)
+                flPath = flWithoutExtn + "_ext" + baseFileExt
               }
-              else initialFileName
+              flPath
+            } else {
+              initialFileName
             }
-            else initialFileName
-
 
           if (isParquet) {
             //TODO : is it better to cache parsed schemas in a map ?
@@ -777,6 +789,7 @@ class SmartFileProducer(val inputConfig: AdapterConfiguration, val nodeContext: 
 
   override def send(message: Array[Array[Byte]], partitionKey: Array[Array[Byte]]): Unit = {
     // Not implemented yet
+    throw new Exception("Not yet implemented")
   }
 
 

--- a/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/SmartFileProducer.scala
+++ b/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/SmartFileProducer.scala
@@ -705,11 +705,14 @@ class SmartFileProducer(val inputConfig: AdapterConfiguration, val nodeContext: 
               } else initialFileName
             } else if (isAvro) {
               // BUGBUG:: Does not want to append the data for the same file for now. Later we can use appendTo while creating the file
+              val curTm = System.currentTimeMillis
               val extLen = baseFileExt.length
               var flPath = initialFileName
+              var cntr = 1L
               while (isFileExists(fc, flPath)) {
                 val flWithoutExtn = flPath.substring(0, flPath.length - extLen)
-                flPath = flWithoutExtn + "_ext" + baseFileExt
+                flPath = flWithoutExtn + "_" + curTm + "_" + cntr + baseFileExt
+                cntr += 1
               }
               flPath
             } else {

--- a/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/StreamPartitionFile.scala
+++ b/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/OutputAdapters/StreamPartitionFile.scala
@@ -10,11 +10,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.logging.log4j.LogManager
+import org.apache.avro.generic.{GenericDatumWriter, GenericRecord, GenericRecordBuilder}
+import org.apache.avro.file.{DataFileWriter, CodecFactory}
 
 import scala.collection.mutable.ArrayBuffer
 
 
-class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) extends PartitionFile{
+class StreamPartitionFile(fc: SmartFileProducerConfiguration, key: String, val avroSchemaStr: String) extends PartitionFile {
 
   private[this] val LOG = LogManager.getLogger(getClass)
   private val FAIL_WAIT = 2000
@@ -32,6 +34,12 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
 
   val canAppend = true
 
+  val isAvroFile = fc.isAvro
+  val avroSchema = if (isAvroFile) Utils.getAvroSchema(avroSchemaStr, Array[String]()) else null
+
+  var writer: GenericDatumWriter[GenericRecord] = null
+  var dataFileWriter: DataFileWriter[GenericRecord] = null
+
   def init(filePath: String, flushBufferSize: Long) = {
     this.flushBufferSize = flushBufferSize
     this.filePath = filePath
@@ -47,6 +55,17 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
     var originalStream : OutputStream = null
     //os = openFile(fc, fileName)
     val osWriter = new com.ligadata.OutputAdapters.OutputStreamWriter()
+
+    // BUGBUG:: Need to use appendTo later if file already exists. At this moment we can not use it with outStream.
+    // BUGBUG:: At this moment we are making sure we don't get existing file from caller.
+    if (isAvroFile) {
+      var fp = filePath
+      while (osWriter.isFileExists(fc, fp)) {
+        fp = fp + "_1"
+      }
+      filePath = fp
+    }
+
     originalStream = osWriter.openFile(fc, filePath, canAppend)
 
     if (compress)
@@ -55,6 +74,22 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
       os = originalStream
 
     outStream = new PartitionStream(os, originalStream)
+
+    if (isAvroFile) {
+      writer = new GenericDatumWriter[GenericRecord](avroSchema)
+      dataFileWriter = new DataFileWriter[GenericRecord](writer)
+      val codec: String = fc.avroCodec
+      if(codec == null || "".equals(codec)) {
+        LOG.info("Not using compression for avro file.");
+        dataFileWriter.setCodec(CodecFactory.fromString("null"));
+      } else {
+        LOG.info("Using " + codec + " compression for avro file.");
+        dataFileWriter.setCodec(CodecFactory.fromString(codec));
+      }
+
+      // BUGBUG:: Need to use appendTo later if file already exists. At this moment we can not use it with outStream.
+      dataFileWriter.create(avroSchema, outStream)
+    }
   }
 
   def getKey: String = key
@@ -66,8 +101,12 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
   def getSize: Long = size
 
   def close() : Unit = {
-    if(outStream != null)
+    if (dataFileWriter != null)
+      dataFileWriter.close()
+    dataFileWriter = null
+    if (outStream != null)
       outStream.close()
+    outStream = null
   }
 
   def getFlushBufferSize: Long = flushBufferSize
@@ -192,6 +231,29 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
   def send(tnxCtxt: TransactionContext, record: ContainerInterface,
            serializer : SmartFileProducer) : Int = {
 
+    if (isAvroFile) {
+      this.synchronized {
+        try {
+          val recBuilder = new GenericRecordBuilder(avroSchema)
+          val attrs = record.getAllAttributeValues
+
+          attrs.foreach(att => {
+            recBuilder.set(att.getValueType().getName, att.getValue)
+          })
+
+          val rec = recBuilder.build
+          dataFileWriter.append(rec)
+          return SendStatus.SUCCESS
+        } catch {
+          case e: Throwable => {
+            LOG.error("Smart File Producer " + fc.Name + ": Unable to write output message into avro", e)
+            throw e
+          }
+        }
+      }
+      return SendStatus.FAILURE
+    }
+
     val (outContainers, serializedContainerData, serializerNames) = serializer.serialize(tnxCtxt, Array(record))
 
     if (1 != serializedContainerData.length || 1 != serializerNames.length) {
@@ -281,7 +343,9 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
     while (!isSuccess) {
       try {
         this.synchronized {
-
+          if (isAvroFile) {
+            dataFileWriter.flush()
+          } else {
             if (flushBufferSize > 0 && streamBuffer.size > 0) {
               writeStream(fc, streamBuffer.toArray)
               size += streamBuffer.size
@@ -289,6 +353,7 @@ class StreamPartitionFile(fc : SmartFileProducerConfiguration, key : String) ext
               streamBuffer.clear()
               recordsInBuffer = 0
             }
+          }
         }
         isSuccess = true
       } catch {


### PR DESCRIPTION
Added avro support.

We are simply providing AVRO & its codec to Compression in smart file output adapter config.

Here is the sample for full adapter config

    {
      "Name": "SmartFileOutputAdapter",
      "TypeString": "Output",
      "TenantId": "tenant1",
      "ClassName": "com.ligadata.OutputAdapters.SmartFileProducer$",
      "DependencyJars": [
      ],
      "AdapterSpecificCfg": {
        "Uri": "file://tmp/output",
        "FileNamePrefix": "Data",
        "PartitionBuckets": "1",
        "RolloverInterval": "1",
        "UseTypeFullNameForPartition": false,
        "Compression": "avro/snappy"
      }
    },
If you don't want to specify any codec, just specify this
"Compression": "avro"

If you specify snappy codec, use this
"Compression": "avro/snappy"
