### PR TITLE
fixing a bug regarding reading files in an hdfs folder subdirs: remove protocol and name node from discovered hdfs subdirs

### DIFF
--- a/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/InputAdapters/hdfs/HdfsFileHandler.scala
+++ b/trunk/InputOutputAdapters/SmartFileAdapter/src/main/scala/com/ligadata/InputAdapters/hdfs/HdfsFileHandler.scala
@@ -325,10 +325,13 @@ class HdfsFileHandler extends SmartFileHandler {
   private def makeFileEntry(fileStatus: FileStatus, parentfolder: String): MonitoredFile = {
 
     val lastReportedSize = fileStatus.getLen
-    val path = fileStatus.getPath.toString
     val lastModificationTime = fileStatus.getModificationTime
     val isDirectory = fileStatus.isDirectory
+
+    //since base dir does not have protocol, let all subdirs be similar
+    val path = if(isDirectory) HdfsUtility.getFilePathNoProtocol(fileStatus.getPath.toString) else fileStatus.getPath.toString
     MonitoredFile(path, parentfolder, lastModificationTime, lastReportedSize, isDirectory, !isDirectory)
+
   }
 
   def listDirectFiles(path : String) :  (Array[MonitoredFile], Array[MonitoredFile]) = {


### PR DESCRIPTION
sicne the path of folders is used to get detailed location config of
each file, and location config src dir does not have protocol within