### PR TITLE
Berkley 1.5.3 flr 634 yousef

### DIFF
--- a/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
+++ b/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
@@ -767,7 +767,7 @@ object FileProcessor {
                         val timeDiff = System.currentTimeMillis/*Calendar.getInstance().getTimeInMillis*/ - fileAgeInt
                         val numberOfFile = getFileInDirectory(processedPath, timeDiff)
                         if (d.lastModified < timeDiff && numberOfFile <= fileCount){
-                            file.setLastModified(Calendar.getInstance().getTimeInMillis)
+                          file.setLastModified(Calendar.getInstance().getTimeInMillis)
                         } else {
                           reprocessOrNewFlag = false
                         }
@@ -834,6 +834,16 @@ object FileProcessor {
                       bufferingQ_map(fileTuple._1) = (thisFileOrigLength, thisFileStarttime, thisFileFailures)
                     }
                     if (logger.isWarnEnabled) logger.warn("SMART_FILE_CONSUMER: IOException trying to monitor the buffering queue for file " + fileTuple._1, ioe)
+                    try {
+                      if(processedPath.equals(MovedPath)){
+                        moveFileToErrorDir(fileTuple._1)
+                        bufferingQRemove(fileTuple._1)
+                      }
+                    } catch {
+                      case e: Throwable => {
+                        logger.error("SMART_FILE_CONSUMER: Failed to move file, retyring", e)
+                      }
+                    }
                   }
                 }
                 case e: Throwable => {
@@ -856,6 +866,16 @@ object FileProcessor {
                       bufferingQ_map(fileTuple._1) = (thisFileOrigLength, thisFileStarttime, thisFileFailures)
                     }
                     logger.error("SMART_FILE_CONSUMER: IOException trying to monitor the buffering queue ", e)
+                    try {
+                      if(processedPath.equals(MovedPath)){
+                        moveFileToErrorDir(fileTuple._1)
+                        bufferingQRemove(fileTuple._1)
+                      }
+                    } catch {
+                      case e: Throwable => {
+                        logger.error("SMART_FILE_CONSUMER: Failed to move file, retyring", e)
+                      }
+                    }
                   }
                 }
               }

--- a/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
+++ b/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
@@ -1630,7 +1630,7 @@ class FileProcessor(val path: ArrayBuffer[Path], val partitionId: Int) {
       }
 
       if(fileAge == null || fileAge.length == 0){
-        logger.warn("SMART_FILE_CONSUMER (" + partitionId + ") file age did not specified. The default value is 30 minute")
+        logger.warn("SMART_FILE_CONSUMER (" + partitionId + ") fileAge did not specify. The default value is 30 minute")
         fileAge = "30m"
       }
 
@@ -1646,7 +1646,7 @@ class FileProcessor(val path: ArrayBuffer[Path], val partitionId: Int) {
       }
 
       if(fileCount == 0){
-        logger.warn("SMART_FILE_CONSUMER (" + partitionId + ") file count did not specified. Th default value is 100")
+        logger.warn("SMART_FILE_CONSUMER (" + partitionId + ") numberOfFiles did not specify. Th default value is 100")
       }
       kafkaTopic = props.getOrElse(SmartFileAdapterConstants.KAFKA_TOPIC, null)
 

--- a/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
+++ b/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
@@ -516,11 +516,11 @@ object FileProcessor {
     fileAge = props.getOrElse(SmartFileAdapterConstants.FILE_AGE,"30m")
     fileAgeInt =
       if(fileAge.takeRight(1) == "s"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_SECOND_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_SECOND_IN_MILLIS
       } else if(fileAge.takeRight(1) == "m"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_MINUTE_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_MINUTE_IN_MILLIS
       }  else if(fileAge.takeRight(1) == "h"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_HOUR_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_HOUR_IN_MILLIS
       } else{
         30 * ONE_MINUTE_IN_MILLIS // default value for file age is 30 minute
       }
@@ -620,19 +620,20 @@ object FileProcessor {
       logger.info("SMART FILE CONSUMER (global):  enq file " + file + " with priority " + createDate + " --- curretnly " + fileQ.size + " files on a QUEUE")
       if (logger.isInfoEnabled) logger.info("SMART FILE CONSUMER (global):  enq file " + file + " with priority " + createDate + " --- curretnly " + fileQ.size + " files on a QUEUE")
       //////////////////////// new code from here
-      val processedPath = file.substring(0,file.lastIndexOf('/')-1)
-      if(processedPath.equals(SmartFileAdapterConstants.DIRECTORY_TO_MOVE_TO)){
-        val timeDiff = System.currentTimeMillis/*Calendar.getInstance().getTimeInMillis*/ - fileAgeInt
-        if (createDate > timeDiff){
-          if(getFileInDirectory(processedPath, timeDiff) <= fileCount){
-            fileQ += new EnqueuedFile(file, offset, createDate, partMap)
-          }
-        }
-      } else {
-        fileQ += new EnqueuedFile(file, offset, createDate, partMap)
-      }
+//      val processedPath = file.substring(0,file.lastIndexOf('/'))
+//      val MovedPath = props.getOrElse(SmartFileAdapterConstants.DIRECTORY_TO_MOVE_TO, "")
+//      if(processedPath.equals(MovedPath)){
+//        val timeDiff = System.currentTimeMillis/*Calendar.getInstance().getTimeInMillis*/ - fileAgeInt
+//        if (createDate > timeDiff){
+//          if(getFileInDirectory(processedPath, timeDiff) <= fileCount){
+//            fileQ += new EnqueuedFile(file, offset, createDate, partMap)
+//          }
+//        }
+//      } else {
+//        fileQ += new EnqueuedFile(file, offset, createDate, partMap)
+//      }
       //////////////////////// to here
-      //fileQ += new EnqueuedFile(file, offset, createDate, partMap)
+      fileQ += new EnqueuedFile(file, offset, createDate, partMap)
     }
   }
 
@@ -770,8 +771,24 @@ object FileProcessor {
                     if (thisFileOrigLength > 0 && FileProcessor.isValidFile(fileTuple._1)) {
                       logger.info("SMART FILE CONSUMER (global):  File READY TO PROCESS " + d.toString)
                       if (logger.isInfoEnabled) logger.info("SMART FILE CONSUMER (global):  File READY TO PROCESS " + d.toString)
-                      enQFile(fileTuple._1, FileProcessor.NOT_RECOVERY_SITUATION, d.lastModified)
-                      bufferingQRemove(fileTuple._1)
+                      ////////////////new code
+                      val processedPath = fileTuple._1.substring(0,fileTuple._1.lastIndexOf('/'))
+                      val MovedPath = props.getOrElse(SmartFileAdapterConstants.DIRECTORY_TO_MOVE_TO, "")
+                      if(processedPath.equals(MovedPath)){
+                        val timeDiff = System.currentTimeMillis/*Calendar.getInstance().getTimeInMillis*/ - fileAgeInt
+                        if (d.lastModified < timeDiff){
+                          if(getFileInDirectory(processedPath, timeDiff) <= fileCount){
+                            enQFile(fileTuple._1, FileProcessor.NOT_RECOVERY_SITUATION, d.lastModified)
+                            bufferingQRemove(fileTuple._1)
+                          }
+                        }
+                      } else {
+                        enQFile(fileTuple._1, FileProcessor.NOT_RECOVERY_SITUATION, d.lastModified)
+                        bufferingQRemove(fileTuple._1)
+                      }
+                      /////////////// to here
+//                      enQFile(fileTuple._1, FileProcessor.NOT_RECOVERY_SITUATION, d.lastModified)
+//                      bufferingQRemove(fileTuple._1)
                     } else {
                       // Here becayse either the file is sitll of len 0,or its deemed to be invalid.
                       if (thisFileOrigLength == 0) {
@@ -1585,11 +1602,11 @@ class FileProcessor(val path: ArrayBuffer[Path], val partitionId: Int) {
 
       fileAgeInt =
         if(fileAge.takeRight(1) == "s"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_SECOND_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_SECOND_IN_MILLIS
       } else if(fileAge.takeRight(1) == "m"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_MINUTE_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_MINUTE_IN_MILLIS
       }  else if(fileAge.takeRight(1) == "h"){
-        fileAge.substring(0, fileAge.length-2).toInt * ONE_HOUR_IN_MILLIS
+        fileAge.substring(0, fileAge.length-1).toInt * ONE_HOUR_IN_MILLIS
       } else{
         30 * ONE_MINUTE_IN_MILLIS // default value for file age is 30 minute
       }

--- a/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
+++ b/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/FileProcessor.scala
@@ -606,7 +606,7 @@ object FileProcessor {
     if(files.exists() && files.isDirectory) {
       val filesList = files.listFiles.filter(_.isFile).toList
       for(file <- filesList){
-        if (file.lastModified > time)
+        if (file.lastModified < time)
           size = size + 1
       }
       size
@@ -757,7 +757,8 @@ object FileProcessor {
 
 
               try {
-                val d = executeCallWithElapsed(new File(fileTuple._1), "Check file for buffering " + fileTuple._1)
+                val file = new File(fileTuple._1)
+                val d = executeCallWithElapsed(file, "Check file for buffering " + fileTuple._1)
                 // If the filesystem is accessible
                 if (d.exists) {
                   logger.info("FileProcessor: monitorBufferingFiles: Processing the file " + fileTuple._1)
@@ -780,6 +781,7 @@ object FileProcessor {
                           if(getFileInDirectory(processedPath, timeDiff) <= fileCount){
                             enQFile(fileTuple._1, FileProcessor.NOT_RECOVERY_SITUATION, d.lastModified)
                             bufferingQRemove(fileTuple._1)
+                            file.setLastModified(Calendar.getInstance().getTimeInMillis);
                           }
                         }
                       } else {

--- a/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/SmartFileAdapterConstants.scala
+++ b/trunk/FileDataConsumer/src/main/scala/com/ligadata/filedataprocessor/SmartFileAdapterConstants.scala
@@ -85,4 +85,9 @@ object SmartFileAdapterConstants {
   val COMPONENT_NAME = "component.name";
   val NODE_ID_PREFIX = "node.id.prefix";
   val ADAPTER_WEIGHT = "adapter.weight";
+
+  // Reprocessing constant
+  val FILE_AGE = "fileAge"
+  val FILE_COUNT = "numberOfFiles"
+  val ERROR_DIR = "moveToErrorDir"
 }


### PR DESCRIPTION
Hi,
steps to run it:
1- in fileProcessor.conf add these moveToDir to dirToWatch.
exp: 
old:
dirToWatch=/tmp/watch/1:/tmp/watch/2
moveToDir=/tmp/processed
new:
dirToWatch=/tmp/watch/1:/tmp/watch/2:/tmp/processed
moveToDir=/tmp/processed
2- add these parameters to fileProcessor.conf.
fileAge : is a number followed by symbol (h : hour, m : minute, s : second ==> lower case) (default value is 30 m)
numberOfFiles : is the limit for number of file that should re-processed (default value is 100)
moveToErrorDir : is the directory that used when re-processing fail (raised an error if did not specify)
ex:
fileAge=3m ==> reprocess the file when the age of that file is less than current time - 3 minute.
numberOfFiles=50 ==> reprocess the file when number of files are less than 50.
moveToErrorDir=/data/fileprocessorerror ==> move the file to this directory if re-processing fail.